### PR TITLE
修复 Example.selectColumns 关键词列名的Bug

### DIFF
--- a/mapper/src/main/java/io/mybatis/mapper/example/Example.java
+++ b/mapper/src/main/java/io/mybatis/mapper/example/Example.java
@@ -22,6 +22,9 @@ import io.mybatis.provider.EntityColumn;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
+
+import static io.mybatis.provider.EntityTable.DELIMITER;
 
 /**
  * 通用的 Example 查询对象
@@ -130,7 +133,13 @@ public class Example<T> {
       if (column.equals(field) || entityColumn.entityTable().useResultMaps()) {
         selectColumns += column;
       } else {
-        selectColumns += column + " AS " + field;
+        Matcher matcher = DELIMITER.matcher(column);
+        //eg: mysql `order` == field order | sqlserver [order] == field order
+        if (matcher.find() && field.equals(matcher.group(1))) {
+          selectColumns += column;
+        } else {
+          selectColumns += column + " AS " + field;
+        }
       }
     }
     return this;


### PR DESCRIPTION
还是上次的问题  https://github.com/mybatis-mapper/mapper/issues/13

只是上次是底层 provider 层处理的通用的字段处理，这次是在查单独列 `example.selectColumns(Fn<T, Object>... fns)` 的时候发现 mapper 中也存在这个问题

--- 

PS:
题外话，中央仓库的 1.0.2 是不是没有 merge develop 分支只是单独的改了版本号就推送了，之前一直是本地 build 的版本，所以开发没有发现之前 `ORDER BY` 的问题