### PR TITLE
Example 系列方法 支持拼接单层级的 OR 条件

### DIFF
--- a/mapper/src/main/java/io/mybatis/mapper/example/ExampleProvider.java
+++ b/mapper/src/main/java/io/mybatis/mapper/example/ExampleProvider.java
@@ -29,6 +29,25 @@ import java.util.stream.Collectors;
  */
 public class ExampleProvider {
 
+  private static final String EXAMPLE_WHERE_CLAUSE_INNER_WHEN =
+          "            <when test=\"criterion.noValue\">\n" +
+          "              AND ${criterion.condition}\n" +
+          "            </when>\n" +
+          "            <when test=\"criterion.singleValue\">\n" +
+          "              AND ${criterion.condition} #{criterion.value}\n" +
+          "            </when>\n" +
+          "            <when test=\"criterion.betweenValue\">\n" +
+          "              AND ${criterion.condition} #{criterion.value} AND\n" +
+          "              #{criterion.secondValue}\n" +
+          "            </when>\n" +
+          "            <when test=\"criterion.listValue\">\n" +
+          "              AND ${criterion.condition}\n" +
+          "              <foreach close=\")\" collection=\"criterion.value\" item=\"listItem\"\n" +
+          "                open=\"(\" separator=\",\">\n" +
+          "                #{listItem}\n" +
+          "              </foreach>\n" +
+          "            </when>\n";
+
   /**
    * example 结构的动态 SQL 查询条件，用于接口参数只有一个 Example 对象时
    */
@@ -38,21 +57,18 @@ public class ExampleProvider {
       "      <trim prefix=\"(\" prefixOverrides=\"AND\" suffix=\")\">\n" +
       "        <foreach collection=\"criteria.criteria\" item=\"criterion\">\n" +
       "          <choose>\n" +
-      "            <when test=\"criterion.noValue\">\n" +
-      "              AND ${criterion.condition}\n" +
-      "            </when>\n" +
-      "            <when test=\"criterion.singleValue\">\n" +
-      "              AND ${criterion.condition} #{criterion.value}\n" +
-      "            </when>\n" +
-      "            <when test=\"criterion.betweenValue\">\n" +
-      "              AND ${criterion.condition} #{criterion.value} AND\n" +
-      "              #{criterion.secondValue}\n" +
-      "            </when>\n" +
-      "            <when test=\"criterion.listValue\">\n" +
-      "              AND ${criterion.condition}\n" +
-      "              <foreach close=\")\" collection=\"criterion.value\" item=\"listItem\"\n" +
-      "                open=\"(\" separator=\",\">\n" +
-      "                #{listItem}\n" +
+                   EXAMPLE_WHERE_CLAUSE_INNER_WHEN +
+      "            <when test=\"criterion.orValue\">\n" +
+      "              <foreach collection=\"criterion.value\" item=\"orCriteria\" separator=\" OR \" open = \" AND (\" close = \")\">\n" +
+      "                <if test=\"orCriteria.valid\">\n" +
+      "                  <trim prefix=\"(\" prefixOverrides=\"AND\" suffix=\")\">\n" +
+      "                    <foreach collection=\"orCriteria.criteria\" item=\"criterion\">\n" +
+      "                      <choose>\n" +
+                               EXAMPLE_WHERE_CLAUSE_INNER_WHEN +
+      "                      </choose>\n" +
+      "                    </foreach>\n" +
+      "                  </trim>\n" +
+      "                </if>\n" +
       "              </foreach>\n" +
       "            </when>\n" +
       "          </choose>\n" +
@@ -66,27 +82,23 @@ public class ExampleProvider {
    * example 结构的动态 SQL 查询条件，用于多个参数时，Example 对应 @Param("example")
    */
   public static final String UPDATE_BY_EXAMPLE_WHERE_CLAUSE = "<where>\n" +
-      "  <foreach collection=\"example.oredCriteria\" item=\"criteria\"\n" +
-      "    separator=\" OR \">\n" +
+      "  <foreach collection=\"example.oredCriteria\" item=\"criteria\"\n separator=\" OR \">\n" +
       "    <if test=\"criteria.valid\">\n" +
       "      <trim prefix=\"(\" prefixOverrides=\"AND\" suffix=\")\">\n" +
       "        <foreach collection=\"criteria.criteria\" item=\"criterion\">\n" +
       "          <choose>\n" +
-      "            <when test=\"criterion.noValue\">\n" +
-      "              AND ${criterion.condition}\n" +
-      "            </when>\n" +
-      "            <when test=\"criterion.singleValue\">\n" +
-      "              AND ${criterion.condition} #{criterion.value}\n" +
-      "            </when>\n" +
-      "            <when test=\"criterion.betweenValue\">\n" +
-      "              AND ${criterion.condition} #{criterion.value} AND\n" +
-      "              #{criterion.secondValue}\n" +
-      "            </when>\n" +
-      "            <when test=\"criterion.listValue\">\n" +
-      "              AND ${criterion.condition}\n" +
-      "              <foreach close=\")\" collection=\"criterion.value\" item=\"listItem\"\n" +
-      "                open=\"(\" separator=\",\">\n" +
-      "                #{listItem}\n" +
+                   EXAMPLE_WHERE_CLAUSE_INNER_WHEN +
+      "            <when test=\"criterion.orValue\">\n" +
+      "              <foreach collection=\"criterion.value\" item=\"orCriteria\" separator=\" OR \" open = \" AND (\" close = \")\">\n" +
+      "                <if test=\"orCriteria.valid\">\n" +
+      "                  <trim prefix=\"(\" prefixOverrides=\"AND\" suffix=\")\">\n" +
+      "                    <foreach collection=\"orCriteria.criteria\" item=\"criterion\">\n" +
+      "                      <choose>\n" +
+                               EXAMPLE_WHERE_CLAUSE_INNER_WHEN +
+      "                      </choose>\n" +
+      "                    </foreach>\n" +
+      "                  </trim>\n" +
+      "                </if>\n" +
       "              </foreach>\n" +
       "            </when>\n" +
       "          </choose>\n" +

--- a/mapper/src/test/java/io/mybatis/mapper/base/UserMapper2Test.java
+++ b/mapper/src/test/java/io/mybatis/mapper/base/UserMapper2Test.java
@@ -18,6 +18,7 @@ package io.mybatis.mapper.base;
 
 import io.mybatis.mapper.BaseMapperTest;
 import io.mybatis.mapper.UserMapper2;
+import io.mybatis.mapper.example.Example;
 import io.mybatis.mapper.fn.Fn;
 import io.mybatis.mapper.model.User;
 import org.apache.ibatis.session.SqlSession;
@@ -119,6 +120,22 @@ public class UserMapper2Test extends BaseMapperTest {
     } finally {
       //不要忘记关闭sqlSession
       sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testOrCondition(){
+    try(SqlSession sqlSession = getSqlSession()){
+      UserMapper2 mapper = sqlSession.getMapper(UserMapper2.class);
+      Example<User> example = mapper.example();
+      example.createCriteria()
+              .andEqualTo(User::getSex,"男")
+              .andOr(example.orPart()
+                              .andLike(User::getUserName,"杨%"),
+                      example.orPart()
+                              .andLike(User::getUserName,"俞%")
+                              .andLike(User::getUserName,"%舟"));
+      Assert.assertEquals(2,mapper.countByExample(example));
     }
   }
 }


### PR DESCRIPTION
尝试性的支持 https://github.com/mybatis-mapper/mapper/issues/15 单层级（不支持 `andOr()` 条件里面 继续嵌套更细粒度的 `andOr()` ）的 or 条件拼接


~~~java
//example:
UserMapper2 mapper = sqlSession.getMapper(UserMapper2.class);
Example<User> example = mapper.example();
example.createCriteria()
        .andEqualTo(User::getSex,"男")
        .andOr(example.orPart()
                        .andLike(User::getUserName,"杨%"),
                example.orPart()
                        .andLike(User::getUserName,"俞%")
                        .andLike(User::getUserName,"%舟"));
~~~

输出SQL（支持 select 和 update）：

~~~sql
xxx WHERE ( sex = ? AND ( ( name LIKE ? ) OR ( name LIKE ? AND name LIKE ? ) ) )
~~~
