### PR TITLE
example / wrapper 新增字符串形式的排序方法重载

### DIFF
--- a/mapper/src/main/java/io/mybatis/mapper/example/Example.java
+++ b/mapper/src/main/java/io/mybatis/mapper/example/Example.java
@@ -19,11 +19,11 @@ package io.mybatis.mapper.example;
 import io.mybatis.mapper.fn.Fn;
 import io.mybatis.provider.EntityColumn;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.mybatis.provider.EntityTable.DELIMITER;
 
@@ -270,6 +270,42 @@ public class Example<T> {
     }
     orderByClause += fn.toColumn() + " " + order;
     return this;
+  }
+
+  /**
+   * 用于一些非常规的排序 或 简单的字符串形式的排序 <br>
+   * 本方法 和 example.setOrderByClause 方法的区别是 <strong>本方法不会覆盖已有的排序内容</strong> <br>
+   * eg：  ORDER BY status = 5 DESC  即将 status = 5 的放在最前面<br>
+   * 此时入参为：<pre><code>example.orderBy("status = 5 DESC")</code></pre>
+   * @param orderByCondition 字符串排序表达式
+   * @return Example
+   */
+  public Example<T> orderBy(String orderByCondition) {
+    if (orderByCondition != null && orderByCondition.length() > 0) {
+      if (orderByClause == null) {
+        orderByClause = "";
+      } else {
+        orderByClause += ", ";
+      }
+      orderByClause += orderByCondition;
+    }
+    return this;
+  }
+
+
+  /**
+   * 用于一些特殊的非常规的排序，排序字符串需要通过一些函数或者方法来构造出来<br>
+   * eg：  ORDER BY FIELD(id,3,1,2) 即将 id 按照 3，1，2 的顺序排序<br>
+   * 此时入参为：<pre><code>example.orderBy(()-> {
+   * return Stream.of(3,1,2)
+   *              .map(Objects::toString)
+   *              .collect(Collectors.joining("," , "FIELD( id ," , ")"));
+   * })</code></pre>
+   * @param orderByCondition 字符串排序表达式
+   * @return Example
+   */
+  public Example<T> orderBy(Supplier<String> orderByCondition) {
+    return orderBy(orderByCondition.get());
   }
 
   /**

--- a/mapper/src/main/java/io/mybatis/mapper/example/ExampleWrapper.java
+++ b/mapper/src/main/java/io/mybatis/mapper/example/ExampleWrapper.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -90,6 +91,36 @@ public class ExampleWrapper<T, I extends Serializable> {
   public ExampleWrapper<T, I> orderBy(Fn<T, Object> fn, Example.Order order) {
     this.example.orderBy(fn, order);
     return this;
+  }
+
+  /**
+   * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
+   * @param orderByCondition 排序字符串（不会覆盖已有的排序内容）
+   * @return Example
+   */
+  public ExampleWrapper<T, I> orderBy(String orderByCondition) {
+    this.example.orderBy(orderByCondition);
+    return this;
+  }
+
+  /**
+   * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
+   * @param orderByCondition 排序字符串构造方法,比如通过数组集合循环拼接等
+   * @return Example
+   */
+  public ExampleWrapper<T, I> orderBy(Supplier<String> orderByCondition) {
+    this.example.orderBy(orderByCondition);
+    return this;
+  }
+
+  /**
+   * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
+   * @param useOrderBy 条件表达式，true使用，false不使用 字符串排序
+   * @param orderByCondition 排序字符串构造方法，比如通过数组集合循环拼接等
+   * @return Example
+   */
+  public ExampleWrapper<T, I> orderBy(boolean useOrderBy, Supplier<String> orderByCondition) {
+    return useOrderBy ? this.orderBy(orderByCondition) : this;
   }
 
   /**


### PR DESCRIPTION
https://github.com/mybatis-mapper/mapper/issues/33

使用示例：
```java
// ORDER BY status = 5 DESC , FIELD(`weight`, 3, 1, 4, 2) , create_time DESC
userMapper.wrapper()
                    // 将 状态 等于5的 排序在最前面
                    .orderBy("status = 5 DESC")    
                    // 如果权重不为空 则将指定权重的值放前面
                    .orderBy(weight != null , () -> "`weight` = " + weight + " DESC")    
                    // 如果指定权重列表不为空，则按照指定的权重特顺序进行排序
                    .orderBy(CollectionUtils.isNotEmpty(assignWeightSort),() -> {
                        return assignWeightSort.stream()
                                        .map(Objects::toString)
                                        .collect(Collectors.joining(",", "FIELD(`weight`,", ")"));
                    })
                    // 相同权重的 按照时间倒序
                    .orderBy("create_time DESC");  //  等同于 .orderByDesc(User::getCreateTime);