### PR TITLE
修复 jpa 模块 获取 Entity 类型错误的问题

### DIFF
--- a/jpa/src/main/java/io/mybatis/provider/jpa/JpaEntityClassFinder.java
+++ b/jpa/src/main/java/io/mybatis/provider/jpa/JpaEntityClassFinder.java
@@ -30,7 +30,7 @@ public class JpaEntityClassFinder extends GenericEntityClassFinder {
   @Override
   public boolean isEntityClass(Class<?> clazz) {
     //带注解或不是简单类型和枚举的都算实体
-    return clazz.isAnnotationPresent(Table.class) || (!SimpleTypeUtil.isSimpleType(clazz) && !clazz.isEnum());
+    return clazz.isAnnotationPresent(Table.class) || (!clazz.isPrimitive() && !SimpleTypeUtil.isSimpleType(clazz) && !clazz.isEnum());
   }
 
   @Override


### PR DESCRIPTION
修复 `SimpleTypeUtil#isSimpleType` 判断基础类型时缺少原始类型判断导致 jpa 模块 update / insert 系列方法获取 Entity 类型错误的问题

https://github.com/mybatis-mapper/mapper/issues/40