### PR TITLE
添加自定义typehandler基类

### DIFF
--- a/mapper/src/main/java/io/mybatis/mapper/base/AbstractTypeHandler.java
+++ b/mapper/src/main/java/io/mybatis/mapper/base/AbstractTypeHandler.java
@@ -1,0 +1,38 @@
+package io.mybatis.mapper.base;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ *
+ * @Author dengsd
+ * @Date 2022/8/6 10:58
+ */
+public abstract class AbstractTypeHandler<T> extends BaseTypeHandler<T> {
+    @Override
+    public void setNonNullParameter(PreparedStatement preparedStatement, int column, T t, JdbcType jdbcType) throws SQLException {
+        preparedStatement.setString(column,this.toJson(t));
+    }
+
+    @Override
+    public T getNullableResult(ResultSet resultSet, String column) throws SQLException {
+        return this.parse(resultSet.getString(column));
+    }
+
+    @Override
+    public T getNullableResult(ResultSet resultSet, int column) throws SQLException {
+        return this.parse(resultSet.getString(column));
+    }
+
+    @Override
+    public T getNullableResult(CallableStatement callableStatement, int column) throws SQLException {
+        return this.parse(callableStatement.getString(column));
+    }
+    protected abstract T parse(String json);
+    protected abstract String toJson(T t);
+}

--- a/mapper/src/main/java/io/mybatis/mapper/list/ListMapper.java
+++ b/mapper/src/main/java/io/mybatis/mapper/list/ListMapper.java
@@ -20,6 +20,7 @@ import io.mybatis.provider.Caching;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Lang;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.UpdateProvider;
 
 import java.util.List;
 
@@ -40,5 +41,8 @@ public interface ListMapper<T> {
   @Lang(Caching.class)
   @InsertProvider(type = ListProvider.class, method = "insertList")
   int insertList(@Param("entityList") List<? extends T> entityList);
+  @Lang(Caching.class)
+  @UpdateProvider(type = ListProvider.class, method = "updateList")
+  int updateList(@Param("entityList") List<? extends T> entityList);
 
 }

--- a/mapper/src/main/java/io/mybatis/mapper/list/ListProvider.java
+++ b/mapper/src/main/java/io/mybatis/mapper/list/ListProvider.java
@@ -16,6 +16,7 @@
 
 package io.mybatis.mapper.list;
 
+import io.mybatis.provider.EntityColumn;
 import io.mybatis.provider.EntityTable;
 import io.mybatis.provider.SqlScript;
 import org.apache.ibatis.annotations.Param;
@@ -47,6 +48,57 @@ public class ListProvider {
             + foreach("entityList", "entity", ",", () ->
             trimSuffixOverrides("(", ")", ",", () ->
                 entity.insertColumns().stream().map(column -> column.variables("entity.")).collect(Collectors.joining(","))));
+      }
+    });
+  }
+
+  /**
+   *
+   *     update cus_address
+   *     <trim prefix="set" suffixOverrides=",">
+   *       <trim prefix="cus_id = case" suffix="end,">
+   *         <foreach collection="list" index="index" item="item">
+   *           when address_id = #{item.addressId,jdbcType=BIGINT} then #{item.cusId,jdbcType=BIGINT}
+   *         </foreach>
+   *       </trim>
+   *     </trim>
+   *     where address_id in
+   *     <foreach close=")" collection="list" item="item" open="(" separator=", ">
+   *       #{item.addressId,jdbcType=BIGINT}
+   *     </foreach>
+   *
+   *
+   * @param providerContext
+   * @param entityList
+   * @return
+   */
+
+  public static String updateList(ProviderContext providerContext, @Param("entityList") List<?> entityList) {
+    if (entityList == null || entityList.size() == 0) {
+      throw new NullPointerException("Parameter cannot be empty");
+    }
+    return SqlScript.caching(providerContext, new SqlScript() {
+      @Override
+      public String getSql(EntityTable entity) {
+        List<EntityColumn> idColumns = entity.idColumns();
+        EntityColumn entityColumn = idColumns.get(0);
+        return "UPDATE "
+                + entity.tableName()
+                + trimSuffixOverrides( "SET"," ",",",()->
+
+                  entity.insertColumns().stream().map(column->
+                    trimSuffixOverrides(column.column()+" = case ","end, ","",()->
+                                    foreach("entityList", "entity", ",", () ->
+                                            trimSuffixOverrides(" ", " ", " ", () ->
+                                                    "when "+entityColumn.columnEqualsProperty("entity.")+" then "+column.variables("entity.")
+                    ))
+                            )
+                  ).collect(Collectors.joining(","))
+                )
+                + where(()->foreach("entityList","entity",()->
+                        entityColumn.columnAsProperty("entity.")
+                ));
+
       }
     });
   }

--- a/mapper/src/test/java/io/mybatis/mapper/list/UserIdsListMapperTest.java
+++ b/mapper/src/test/java/io/mybatis/mapper/list/UserIdsListMapperTest.java
@@ -48,7 +48,28 @@ public class UserIdsListMapperTest extends BaseMapperTest {
       sqlSession.close();
     }
   }
+  @Test
+  public void testUpdateList() {
+    SqlSession sqlSession = getSqlSession();
+    try {
+      UserIdsMapper insertListMapper = sqlSession.getMapper(UserIdsMapper.class);
+      List<UserIds> users = new ArrayList<>(10);
+      for (int i = 0; i < 2; i++) {
+        UserIds user = new UserIds();
+        user.setId1(2L);
+        user.setId2((long) i);
+        user.setName("测试" + i);
+        users.add(user);
+      }
+      Assert.assertEquals(2, insertListMapper.insertList(users));
 
+      Assert.assertEquals(2, insertListMapper.updateList(users));
+      sqlSession.rollback();
+    } finally {
+      //不要忘记关闭sqlSession
+      sqlSession.close();
+    }
+  }
 }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>io.mybatis</groupId>
         <artifactId>mybatis-provider</artifactId>
-        <version>${provider.version}</version>
+        <version>2.1.2-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <argLine>-Dfile.encoding=UTF-8</argLine>
-
-    <provider.version>2.1.1</provider.version>
-
+    <provider.version>2.1.2-SNAPSHOT</provider.version>
     <mybatis.version>3.5.10</mybatis.version>
     <mybatis-spring.version>2.0.7</mybatis-spring.version>
     <mybatis-spring-boot.version>2.2.2</mybatis-spring-boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
   </modules>
 
   <properties>
-    <revision>2.0.0</revision>
+    <revision>2.0.1-SNAPSHOT</revision>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
使用：
1、实现
@MappedTypes({Arrays.class})
@MappedJdbcTypes(JdbcType.ARRAY)
public class FastjsonArrayHandler extends AbstractTypeHandler<List> {

    @Override
    protected List parse(String json) {
        return  StringUtils.isBlank(json) ? null : JSONObject.parseObject(json,new TypeReference<List>(){}.getType());
    }

    @Override
    protected String toJson(List list) {
        return  JSONObject.toJSONString(list);
    }
}
2 、实体类里面添加 
   @Entity.Table(value = "model_category",autoResultMap = true)

3、对应的字段添加 

  @Entity.Column(value = "interfaces",typeHandler = FastjsonArrayHandler.class)
    private List<ModelInterface> interfaces;
