### PR TITLE
Fixed "UNKONWN" typo in common module

### DIFF
--- a/common/src/main/java/io/mybatis/common/core/Code.java
+++ b/common/src/main/java/io/mybatis/common/core/Code.java
@@ -28,7 +28,7 @@ public class Code {
   public static final I18n.Language LANG           = I18n.language(CODE_BUNDLE);
   public static final Code          SUCCESS        = new Code("00000");
   public static final Code          FAILURE        = new Code("M0100");
-  public static final Code          UNKONWN        = new Code("M0200");
+  public static final Code          UNKNOWN        = new Code("M0200");
   public static final Code          SAVE_FAILURE   = new Code("M0201");
   public static final Code          UPDATE_FAILURE = new Code("M0202");
   public static final Code          DELETE_FAILURE = new Code("M0203");

--- a/common/src/main/java/io/mybatis/common/core/Response.java
+++ b/common/src/main/java/io/mybatis/common/core/Response.java
@@ -47,7 +47,7 @@ public class Response<T extends Response> {
   }
 
   public static Response error() {
-    return error(Code.UNKONWN);
+    return error(Code.UNKNOWN);
   }
 
   public static Response error(String code) {
@@ -55,7 +55,7 @@ public class Response<T extends Response> {
   }
 
   public static Response error(Throwable t) {
-    return error(Code.UNKONWN.getCode(), t.getMessage());
+    return error(Code.UNKNOWN.getCode(), t.getMessage());
   }
 
   public static Response error(ServiceException e) {

--- a/common/src/main/resources/mybatis_common_code_en.properties
+++ b/common/src/main/resources/mybatis_common_code_en.properties
@@ -15,7 +15,7 @@
 #
 00000=Success
 M0100=Failure
-M0200=Unkonwn
+M0200=Unknown
 M0201=Save failure
 M0202=Update failure
 M0203=Delete failure

--- a/common/src/test/java/io/mybatis/common/util/I18nTest.java
+++ b/common/src/test/java/io/mybatis/common/util/I18nTest.java
@@ -28,7 +28,7 @@ public class I18nTest {
     Locale.setDefault(Locale.CHINA);
     org.junit.Assert.assertEquals("操作成功", Code.SUCCESS.getMessage());
     org.junit.Assert.assertEquals("操作失败", Code.FAILURE.getMessage());
-    org.junit.Assert.assertEquals("未知错误", Code.UNKONWN.getMessage());
+    org.junit.Assert.assertEquals("未知错误", Code.UNKNOWN.getMessage());
     org.junit.Assert.assertEquals("保存失败", Code.SAVE_FAILURE.getMessage());
     org.junit.Assert.assertEquals("修改失败", Code.UPDATE_FAILURE.getMessage());
     org.junit.Assert.assertEquals("删除失败", Code.DELETE_FAILURE.getMessage());


### PR DESCRIPTION
Fixed "UNKONWN" typo in common module.
Searched all the occurrence in common module and replaced them.