### PR TITLE
feat(mapper): 新增wrapper类及mapper实现

### DIFF
--- a/mapper/src/main/java/io/mybatis/mapper/example/AbstractExampleWrapper.java
+++ b/mapper/src/main/java/io/mybatis/mapper/example/AbstractExampleWrapper.java
@@ -1,0 +1,856 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mybatis.mapper.example;
+
+import io.mybatis.mapper.fn.Fn;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * 抽象类： 封装 Example 的查询条件，方便链式调用
+ *
+ * @param <T> 实体类类型
+ * @param <E> 实现类类型
+ * @author liuzh
+ */
+public abstract class AbstractExampleWrapper<T, E> {
+  protected final Example<T>          example;
+  protected       Example.Criteria<T> current;
+
+  public AbstractExampleWrapper(Example<T> example) {
+    this.example = example;
+    this.current = example.createCriteria();
+  }
+
+  public abstract E getSelf();
+
+  /**
+   * or 一组条件
+   *
+   * @return 条件
+   */
+  public E or() {
+    this.current = this.example.or();
+    return getSelf();
+  }
+
+  /**
+   * 获取查询条件
+   */
+  public Example<T> example() {
+    return example;
+  }
+
+  /**
+   * 清除条件，可重用
+   */
+  public E clear() {
+    this.example.clear();
+    this.current = example.createCriteria();
+    return getSelf();
+  }
+
+  /**
+   * 指定查询列
+   *
+   * @param fns 方法引用
+   */
+  @SafeVarargs
+  public final E select(Fn<T, Object>... fns) {
+    this.example.selectColumns(fns);
+    return getSelf();
+  }
+
+  /**
+   * 排除指定查询列
+   *
+   * @param fns 方法引用
+   */
+  @SafeVarargs
+  public final E exclude(Fn<T, Object>... fns) {
+    this.example.excludeColumns(fns);
+    return getSelf();
+  }
+
+  /**
+   * 设置起始 SQL
+   *
+   * @param startSql 起始 SQL，添加到 SQL 前，注意防止 SQL 注入
+   */
+  public E startSql(String startSql) {
+    this.example.setStartSql(startSql);
+    return getSelf();
+  }
+
+  /**
+   * 设置结尾 SQL
+   *
+   * @param endSql 结尾 SQL，添加到 SQL 最后，注意防止 SQL 注入
+   */
+  public E endSql(String endSql) {
+    this.example.setEndSql(endSql);
+    return getSelf();
+  }
+
+  /**
+   * 通过方法引用方式设置排序字段
+   *
+   * @param fn    排序列的方法引用
+   * @param order 排序方式
+   * @return Example
+   */
+  public E orderBy(Fn<T, Object> fn, Example.Order order) {
+    this.example.orderBy(fn, order);
+    return getSelf();
+  }
+
+  /**
+   * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
+   *
+   * @param orderByCondition 排序字符串（不会覆盖已有的排序内容）
+   * @return Example
+   */
+  public E orderBy(String orderByCondition) {
+    this.example.orderBy(orderByCondition);
+    return getSelf();
+  }
+
+  /**
+   * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
+   *
+   * @param orderByCondition 排序字符串构造方法,比如通过数组集合循环拼接等
+   * @return Example
+   */
+  public E orderBy(Supplier<String> orderByCondition) {
+    this.example.orderBy(orderByCondition);
+    return getSelf();
+  }
+
+  /**
+   * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
+   *
+   * @param useOrderBy       条件表达式，true使用，false不使用 字符串排序
+   * @param orderByCondition 排序字符串构造方法，比如通过数组集合循环拼接等
+   * @return Example
+   */
+  public E orderBy(boolean useOrderBy, Supplier<String> orderByCondition) {
+    return useOrderBy ? this.orderBy(orderByCondition) : getSelf();
+  }
+
+  /**
+   * 通过方法引用方式设置排序字段，升序排序
+   *
+   * @param fns 排序列的方法引用
+   * @return Example
+   */
+  @SafeVarargs
+  public final E orderByAsc(Fn<T, Object>... fns) {
+    this.example.orderByAsc(fns);
+    return getSelf();
+  }
+
+  /**
+   * 通过方法引用方式设置排序字段，降序排序
+   *
+   * @param fns 排序列的方法引用
+   * @return Example
+   */
+  @SafeVarargs
+  public final E orderByDesc(Fn<T, Object>... fns) {
+    this.example.orderByDesc(fns);
+    return getSelf();
+  }
+
+  /**
+   * 设置 distince
+   */
+  public E distinct() {
+    this.example.setDistinct(true);
+    return getSelf();
+  }
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param useSet 表达式条件, true 使用，false 不使用
+   * @param setSql "column = value"
+   */
+  public E set(boolean useSet, String setSql) {
+    return useSet ? set(setSql) : getSelf();
+  }
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param setSql "column = value"
+   */
+  public E set(String setSql) {
+    this.example.set(setSql);
+    return getSelf();
+  }
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param useSet 表达式条件, true 使用，false 不使用
+   * @param fn     字段
+   * @param value  值
+   */
+  public E set(boolean useSet, Fn<T, Object> fn, Object value) {
+    return useSet ? set(fn, value) : getSelf();
+  }
+
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param useSet   表达式条件, true 使用，false 不使用
+   * @param fn       字段
+   * @param supplier 值构造函数
+   */
+  public E set(boolean useSet, Fn<T, Object> fn, Supplier<Object> supplier) {
+    return useSet ? set(fn, supplier.get()) : getSelf();
+  }
+
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param fn    字段
+   * @param value 值
+   */
+  public E set(Fn<T, Object> fn, Object value) {
+    this.example.set(fn, value);
+    return getSelf();
+  }
+
+  /**
+   * 指定字段为 null
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   */
+  public E isNull(boolean useCondition, Fn<T, Object> fn) {
+    return useCondition ? isNull(fn) : getSelf();
+  }
+
+  /**
+   * 指定字段为 null
+   *
+   * @param fn 字段对应的 get 方法引用
+   */
+  public E isNull(Fn<T, Object> fn) {
+    this.current.addCriterion(fn.toColumn() + " IS NULL");
+    return getSelf();
+  }
+
+  /**
+   * 指定字段不为 null
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   */
+  public E isNotNull(boolean useCondition, Fn<T, Object> fn) {
+    return useCondition ? isNotNull(fn) : getSelf();
+  }
+
+  /**
+   * 指定字段不为 null
+   *
+   * @param fn 字段对应的 get 方法引用
+   */
+  public E isNotNull(Fn<T, Object> fn) {
+    this.current.addCriterion(fn.toColumn() + " IS NOT NULL");
+    return getSelf();
+  }
+
+  /**
+   * 字段 = 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值
+   */
+  public E eq(boolean useCondition, Fn<T, Object> fn, Object value) {
+    return useCondition ? eq(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 = 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数
+   */
+  public E eq(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+    return useCondition ? eq(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 = 值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值
+   */
+  public E eq(Fn<T, Object> fn, Object value) {
+    this.current.addCriterion(fn.toColumn() + " =", value);
+    return getSelf();
+  }
+
+  /**
+   * 字段 != 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数
+   */
+  public E ne(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+    return useCondition ? ne(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 != 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值
+   */
+  public E ne(boolean useCondition, Fn<T, Object> fn, Object value) {
+    return useCondition ? ne(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 != 值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值
+   */
+  public E ne(Fn<T, Object> fn, Object value) {
+    this.current.addCriterion(fn.toColumn() + " <>", value);
+    return getSelf();
+  }
+
+  /**
+   * 字段 > 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数
+   */
+  public E gt(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+    return useCondition ? gt(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 > 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值
+   */
+  public E gt(boolean useCondition, Fn<T, Object> fn, Object value) {
+    return useCondition ? gt(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 > 值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值
+   */
+  public E gt(Fn<T, Object> fn, Object value) {
+    this.current.addCriterion(fn.toColumn() + " >", value);
+    return getSelf();
+  }
+
+  /**
+   * 字段 >= 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数
+   */
+  public E ge(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+    return useCondition ? ge(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 >= 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值
+   */
+  public E ge(boolean useCondition, Fn<T, Object> fn, Object value) {
+    return useCondition ? ge(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 >= 值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值
+   */
+  public E ge(Fn<T, Object> fn, Object value) {
+    this.current.addCriterion(fn.toColumn() + " >=", value);
+    return getSelf();
+  }
+
+  /**
+   * 字段 < 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   */
+  public E lt(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+    return useCondition ? lt(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 < 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值
+   */
+  public E lt(boolean useCondition, Fn<T, Object> fn, Object value) {
+    return useCondition ? lt(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 < 值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值
+   */
+  public E lt(Fn<T, Object> fn, Object value) {
+    this.current.addCriterion(fn.toColumn() + " <", value);
+    return getSelf();
+  }
+
+  /**
+   * 字段 <= 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值
+   */
+  public E le(boolean useCondition, Fn<T, Object> fn, Object value) {
+    return useCondition ? le(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 <= 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数
+   */
+  public E le(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+    return useCondition ? le(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 <= 值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值
+   */
+  public E le(Fn<T, Object> fn, Object value) {
+    this.current.addCriterion(fn.toColumn() + " <=", value);
+    return getSelf();
+  }
+
+  /**
+   * 字段 in (值集合)
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param values       值集合
+   */
+  @SuppressWarnings("rawtypes")
+  public E in(boolean useCondition, Fn<T, Object> fn, Iterable values) {
+    return useCondition ? in(fn, values) : getSelf();
+  }
+
+  /**
+   * 字段 in (值集合)
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值集合构造函数
+   */
+  @SuppressWarnings("rawtypes")
+  public E in(boolean useCondition, Fn<T, Object> fn, Supplier<Iterable> supplier) {
+    return useCondition ? in(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 in (值集合)
+   *
+   * @param fn     字段对应的 get 方法引用
+   * @param values 值集合
+   */
+  @SuppressWarnings("rawtypes")
+  public E in(Fn<T, Object> fn, Iterable values) {
+    this.current.addCriterion(fn.toColumn() + " IN", values);
+    return getSelf();
+  }
+
+  /**
+   * 字段 not in (值集合)
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param values       值集合
+   */
+  @SuppressWarnings("rawtypes")
+  public E notIn(boolean useCondition, Fn<T, Object> fn, Iterable values) {
+    return useCondition ? notIn(fn, values) : getSelf();
+  }
+
+  /**
+   * 字段 not in (值集合)
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值集合构造函数
+   */
+  @SuppressWarnings("rawtypes")
+  public E notIn(boolean useCondition, Fn<T, Object> fn, Supplier<Iterable> supplier) {
+    return useCondition ? notIn(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 not in (值集合)
+   *
+   * @param fn     字段对应的 get 方法引用
+   * @param values 值集合
+   */
+  @SuppressWarnings("rawtypes")
+  public E notIn(Fn<T, Object> fn, Iterable values) {
+    this.current.addCriterion(fn.toColumn() + " NOT IN", values);
+    return getSelf();
+  }
+
+  /**
+   * 字段 between value1 and value 2
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value1       值1
+   * @param value2       值2
+   */
+  public E between(boolean useCondition, Fn<T, Object> fn, Object value1, Object value2) {
+    return useCondition ? between(fn, value1, value2) : getSelf();
+  }
+
+  /**
+   * 字段 between value1 and value 2
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier1    值1构造函数
+   * @param supplier2    值2构造函数
+   */
+  public E between(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier1, Supplier<Object> supplier2) {
+    return useCondition ? between(fn, supplier1.get(), supplier2.get()) : getSelf();
+  }
+
+  /**
+   * 字段 between value1 and value 2
+   *
+   * @param fn     字段对应的 get 方法引用
+   * @param value1 值1
+   * @param value2 值2
+   */
+  public E between(Fn<T, Object> fn, Object value1, Object value2) {
+    this.current.addCriterion(fn.toColumn() + " BETWEEN", value1, value2);
+    return getSelf();
+  }
+
+  /**
+   * 字段 not between value1 and value 2
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value1       值1
+   * @param value2       值2
+   */
+  public E notBetween(boolean useCondition, Fn<T, Object> fn, Object value1, Object value2) {
+    return useCondition ? notBetween(fn, value1, value2) : getSelf();
+  }
+
+  /**
+   * 字段 not between value1 and value 2
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier1    值1构造函数
+   * @param supplier2    值2构造函数
+   */
+  public E notBetween(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier1, Supplier<Object> supplier2) {
+    return useCondition ? notBetween(fn, supplier1.get(), supplier2.get()) : getSelf();
+  }
+
+  /**
+   * 字段 not between value1 and value 2
+   *
+   * @param fn     字段对应的 get 方法引用
+   * @param value1 值1
+   * @param value2 值2
+   */
+  public E notBetween(Fn<T, Object> fn, Object value1, Object value2) {
+    this.current.addCriterion(fn.toColumn() + " NOT BETWEEN", value1, value2);
+    return getSelf();
+  }
+
+  /**
+   * 字段 like %值%
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值，两侧自动添加 %
+   */
+  public E contains(boolean useCondition, Fn<T, Object> fn, String value) {
+    return useCondition ? contains(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 like %值%
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数，两侧自动添加 %
+   */
+  public E contains(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
+    return useCondition ? contains(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 like %值%
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值，两侧自动添加 %
+   */
+  public E contains(Fn<T, Object> fn, String value) {
+    this.current.addCriterion(fn.toColumn() + "  LIKE", "%" + value + "%");
+    return getSelf();
+  }
+
+  /**
+   * 字段 like 值%，匹配 value 为前缀的值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值，右侧自动添加 %
+   */
+  public E startsWith(boolean useCondition, Fn<T, Object> fn, String value) {
+    return useCondition ? startsWith(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 like 值%，匹配 value 为前缀的值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数，右侧自动添加 %
+   */
+  public E startsWith(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
+    return useCondition ? startsWith(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 like 值%，匹配 value 为前缀的值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值，右侧自动添加 %
+   */
+  public E startsWith(Fn<T, Object> fn, String value) {
+    this.current.addCriterion(fn.toColumn() + "  LIKE", value + "%");
+    return getSelf();
+  }
+
+  /**
+   * 字段 like %值，匹配 value 为后缀的值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值，左侧自动添加 %
+   */
+  public E endsWith(boolean useCondition, Fn<T, Object> fn, String value) {
+    return useCondition ? endsWith(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 like %值，匹配 value 为后缀的值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数，左侧自动添加 %
+   */
+  public E endsWith(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
+    return useCondition ? endsWith(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 like %值，匹配 value 为后缀的值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值，左侧自动添加 %
+   */
+  public E endsWith(Fn<T, Object> fn, String value) {
+    this.current.addCriterion(fn.toColumn() + "  LIKE", "%" + value);
+    return getSelf();
+  }
+
+  /**
+   * 字段 like 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值，需要指定 '%'(多个), '_'(单个) 模糊匹配
+   */
+  public E like(boolean useCondition, Fn<T, Object> fn, String value) {
+    return useCondition ? like(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 like 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数，需要指定 '%'(多个), '_'(单个) 模糊匹配
+   */
+  public E like(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
+    return useCondition ? like(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 like 值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值，需要指定 '%'(多个), '_'(单个) 模糊匹配
+   */
+  public E like(Fn<T, Object> fn, String value) {
+    this.current.addCriterion(fn.toColumn() + "  LIKE", value);
+    return getSelf();
+  }
+
+  /**
+   * 字段 not like 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param value        值，需要指定 % 模糊匹配
+   */
+  public E notLike(boolean useCondition, Fn<T, Object> fn, String value) {
+    return useCondition ? notLike(fn, value) : getSelf();
+  }
+
+  /**
+   * 字段 not like 值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param fn           字段对应的 get 方法引用
+   * @param supplier     值构造函数，需要指定 % 模糊匹配
+   */
+  public E notLike(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
+    return useCondition ? notLike(fn, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 字段 not like 值
+   *
+   * @param fn    字段对应的 get 方法引用
+   * @param value 值，需要指定 % 模糊匹配
+   */
+  public E notLike(Fn<T, Object> fn, String value) {
+    this.current.addCriterion(fn.toColumn() + "  NOT LIKE", value);
+    return getSelf();
+  }
+
+  /**
+   * 添加任意条件，条件一定是后端使用的，需要自己防止 SQL 注入
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param condition    任意条件，例如 "length(countryname)<5"
+   */
+  public E anyCondition(boolean useCondition, String condition) {
+    return useCondition ? anyCondition(condition) : getSelf();
+  }
+
+  /**
+   * 添加任意条件，条件一定是后端使用的，需要自己防止 SQL 注入
+   *
+   * @param condition 任意条件，例如 "length(countryname)<5"
+   */
+  public E anyCondition(String condition) {
+    this.current.andCondition(condition);
+    return getSelf();
+  }
+
+  /**
+   * 手写左边条件，右边用value值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param condition    例如 "length(countryname)="
+   * @param value        例如 5
+   */
+  public E anyCondition(boolean useCondition, String condition, Object value) {
+    return useCondition ? anyCondition(condition, value) : getSelf();
+  }
+
+  /**
+   * 手写左边条件，右边用value值
+   *
+   * @param useCondition 表达式条件, true 使用，false 不使用
+   * @param condition    例如 "length(countryname)="
+   * @param supplier     任意条件值的构造函数
+   */
+  public E anyCondition(boolean useCondition, String condition, Supplier<Object> supplier) {
+    return useCondition ? anyCondition(condition, supplier.get()) : getSelf();
+  }
+
+  /**
+   * 手写左边条件，右边用value值
+   *
+   * @param condition 例如 "length(countryname)="
+   * @param value     例如 5
+   */
+  public E anyCondition(String condition, Object value) {
+    this.current.andCondition(condition, value);
+    return getSelf();
+  }
+
+  /**
+   * 嵌套 or 查询，数组多个条件直接使用 or，单个条件中为 and
+   *
+   * @param orParts 条件块
+   */
+  @SafeVarargs
+  public final E or(Function<Example.OrCriteria<T>, Example.OrCriteria<T>>... orParts) {
+    if (orParts != null && orParts.length > 0) {
+      this.current.andOr(Arrays.stream(orParts).map(orPart -> orPart.apply(example.orPart())).collect(Collectors.toList()));
+    }
+    return getSelf();
+  }
+
+}

--- a/mapper/src/main/java/io/mybatis/mapper/example/ExampleWrapper.java
+++ b/mapper/src/main/java/io/mybatis/mapper/example/ExampleWrapper.java
@@ -17,18 +17,13 @@
 package io.mybatis.mapper.example;
 
 import io.mybatis.common.util.Assert;
-import io.mybatis.mapper.BaseMapper;
 import io.mybatis.mapper.fn.Fn;
 import org.apache.ibatis.exceptions.TooManyResultsException;
 import org.apache.ibatis.session.RowBounds;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -38,826 +33,16 @@ import java.util.stream.Stream;
  * @param <I> 主键类型
  * @author liuzh
  */
-public class ExampleWrapper<T, I extends Serializable> {
-  private final BaseMapper<T, I>    baseMapper;
-  private final Example<T>          example;
-  private       Example.Criteria<T> current;
+public class ExampleWrapper<T, I extends Serializable> extends AbstractExampleWrapper<T, ExampleWrapper<T, I>> {
+  private final ExampleMapper<T, Example<T>> exampleMapper;
 
-  public ExampleWrapper(BaseMapper<T, I> baseMapper, Example<T> example) {
-    this.baseMapper = baseMapper;
-    this.example = example;
-    this.current = example.createCriteria();
+  public ExampleWrapper(ExampleMapper<T, Example<T>> exampleMapper, Example<T> example) {
+    super(example);
+    this.exampleMapper = exampleMapper;
   }
 
-  /**
-   * or 一组条件
-   *
-   * @return 条件
-   */
-  public ExampleWrapper<T, I> or() {
-    this.current = this.example.or();
-    return this;
-  }
-
-  /**
-   * 获取查询条件
-   */
-  public Example<T> example() {
-    return example;
-  }
-
-  /**
-   * 清除条件，可重用
-   */
-  public ExampleWrapper<T, I> clear() {
-    this.example.clear();
-    this.current = example.createCriteria();
-    return this;
-  }
-
-  /**
-   * 指定查询列
-   *
-   * @param fns 方法引用
-   */
-  @SafeVarargs
-  public final ExampleWrapper<T, I> select(Fn<T, Object>... fns) {
-    this.example.selectColumns(fns);
-    return this;
-  }
-
-  /**
-   * 排除指定查询列
-   *
-   * @param fns 方法引用
-   */
-  @SafeVarargs
-  public final ExampleWrapper<T, I> exclude(Fn<T, Object>... fns) {
-    this.example.excludeColumns(fns);
-    return this;
-  }
-
-  /**
-   * 设置起始 SQL
-   *
-   * @param startSql 起始 SQL，添加到 SQL 前，注意防止 SQL 注入
-   */
-  public ExampleWrapper<T, I> startSql(String startSql) {
-    this.example.setStartSql(startSql);
-    return this;
-  }
-
-  /**
-   * 设置结尾 SQL
-   *
-   * @param endSql 结尾 SQL，添加到 SQL 最后，注意防止 SQL 注入
-   */
-  public ExampleWrapper<T, I> endSql(String endSql) {
-    this.example.setEndSql(endSql);
-    return this;
-  }
-
-  /**
-   * 通过方法引用方式设置排序字段
-   *
-   * @param fn    排序列的方法引用
-   * @param order 排序方式
-   * @return Example
-   */
-  public ExampleWrapper<T, I> orderBy(Fn<T, Object> fn, Example.Order order) {
-    this.example.orderBy(fn, order);
-    return this;
-  }
-
-  /**
-   * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
-   *
-   * @param orderByCondition 排序字符串（不会覆盖已有的排序内容）
-   * @return Example
-   */
-  public ExampleWrapper<T, I> orderBy(String orderByCondition) {
-    this.example.orderBy(orderByCondition);
-    return this;
-  }
-
-  /**
-   * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
-   *
-   * @param orderByCondition 排序字符串构造方法,比如通过数组集合循环拼接等
-   * @return Example
-   */
-  public ExampleWrapper<T, I> orderBy(Supplier<String> orderByCondition) {
-    this.example.orderBy(orderByCondition);
-    return this;
-  }
-
-  /**
-   * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
-   *
-   * @param useOrderBy       条件表达式，true使用，false不使用 字符串排序
-   * @param orderByCondition 排序字符串构造方法，比如通过数组集合循环拼接等
-   * @return Example
-   */
-  public ExampleWrapper<T, I> orderBy(boolean useOrderBy, Supplier<String> orderByCondition) {
-    return useOrderBy ? this.orderBy(orderByCondition) : this;
-  }
-
-  /**
-   * 通过方法引用方式设置排序字段，升序排序
-   *
-   * @param fns 排序列的方法引用
-   * @return Example
-   */
-  @SafeVarargs
-  public final ExampleWrapper<T, I> orderByAsc(Fn<T, Object>... fns) {
-    this.example.orderByAsc(fns);
-    return this;
-  }
-
-  /**
-   * 通过方法引用方式设置排序字段，降序排序
-   *
-   * @param fns 排序列的方法引用
-   * @return Example
-   */
-  @SafeVarargs
-  public final ExampleWrapper<T, I> orderByDesc(Fn<T, Object>... fns) {
-    this.example.orderByDesc(fns);
-    return this;
-  }
-
-  /**
-   * 设置 distince
-   */
-  public ExampleWrapper<T, I> distinct() {
-    this.example.setDistinct(true);
-    return this;
-  }
-
-  /**
-   * 设置更新字段和值
-   *
-   * @param useSet 表达式条件, true 使用，false 不使用
-   * @param setSql "column = value"
-   */
-  public ExampleWrapper<T, I> set(boolean useSet, String setSql) {
-    return useSet ? set(setSql) : this;
-  }
-
-  /**
-   * 设置更新字段和值
-   *
-   * @param setSql "column = value"
-   */
-  public ExampleWrapper<T, I> set(String setSql) {
-    this.example.set(setSql);
-    return this;
-  }
-
-  /**
-   * 设置更新字段和值
-   *
-   * @param useSet 表达式条件, true 使用，false 不使用
-   * @param fn     字段
-   * @param value  值
-   */
-  public ExampleWrapper<T, I> set(boolean useSet, Fn<T, Object> fn, Object value) {
-    return useSet ? set(fn, value) : this;
-  }
-
-
-  /**
-   * 设置更新字段和值
-   *
-   * @param useSet   表达式条件, true 使用，false 不使用
-   * @param fn       字段
-   * @param supplier 值构造函数
-   */
-  public ExampleWrapper<T, I> set(boolean useSet, Fn<T, Object> fn, Supplier<Object> supplier) {
-    return useSet ? set(fn, supplier.get()) : this;
-  }
-
-
-  /**
-   * 设置更新字段和值
-   *
-   * @param fn    字段
-   * @param value 值
-   */
-  public ExampleWrapper<T, I> set(Fn<T, Object> fn, Object value) {
-    this.example.set(fn, value);
-    return this;
-  }
-
-  /**
-   * 指定字段为 null
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   */
-  public ExampleWrapper<T, I> isNull(boolean useCondition, Fn<T, Object> fn) {
-    return useCondition ? isNull(fn) : this;
-  }
-
-  /**
-   * 指定字段为 null
-   *
-   * @param fn 字段对应的 get 方法引用
-   */
-  public ExampleWrapper<T, I> isNull(Fn<T, Object> fn) {
-    this.current.addCriterion(fn.toColumn() + " IS NULL");
-    return this;
-  }
-
-  /**
-   * 指定字段不为 null
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   */
-  public ExampleWrapper<T, I> isNotNull(boolean useCondition, Fn<T, Object> fn) {
-    return useCondition ? isNotNull(fn) : this;
-  }
-
-  /**
-   * 指定字段不为 null
-   *
-   * @param fn 字段对应的 get 方法引用
-   */
-  public ExampleWrapper<T, I> isNotNull(Fn<T, Object> fn) {
-    this.current.addCriterion(fn.toColumn() + " IS NOT NULL");
-    return this;
-  }
-
-  /**
-   * 字段 = 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值
-   */
-  public ExampleWrapper<T, I> eq(boolean useCondition, Fn<T, Object> fn, Object value) {
-    return useCondition ? eq(fn, value) : this;
-  }
-
-  /**
-   * 字段 = 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数
-   */
-  public ExampleWrapper<T, I> eq(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
-    return useCondition ? eq(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 = 值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值
-   */
-  public ExampleWrapper<T, I> eq(Fn<T, Object> fn, Object value) {
-    this.current.addCriterion(fn.toColumn() + " =", value);
-    return this;
-  }
-
-  /**
-   * 字段 != 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数
-   */
-  public ExampleWrapper<T, I> ne(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
-    return useCondition ? ne(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 != 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值
-   */
-  public ExampleWrapper<T, I> ne(boolean useCondition, Fn<T, Object> fn, Object value) {
-    return useCondition ? ne(fn, value) : this;
-  }
-
-  /**
-   * 字段 != 值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值
-   */
-  public ExampleWrapper<T, I> ne(Fn<T, Object> fn, Object value) {
-    this.current.addCriterion(fn.toColumn() + " <>", value);
-    return this;
-  }
-
-  /**
-   * 字段 > 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数
-   */
-  public ExampleWrapper<T, I> gt(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
-    return useCondition ? gt(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 > 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值
-   */
-  public ExampleWrapper<T, I> gt(boolean useCondition, Fn<T, Object> fn, Object value) {
-    return useCondition ? gt(fn, value) : this;
-  }
-
-  /**
-   * 字段 > 值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值
-   */
-  public ExampleWrapper<T, I> gt(Fn<T, Object> fn, Object value) {
-    this.current.addCriterion(fn.toColumn() + " >", value);
-    return this;
-  }
-
-  /**
-   * 字段 >= 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数
-   */
-  public ExampleWrapper<T, I> ge(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
-    return useCondition ? ge(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 >= 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值
-   */
-  public ExampleWrapper<T, I> ge(boolean useCondition, Fn<T, Object> fn, Object value) {
-    return useCondition ? ge(fn, value) : this;
-  }
-
-  /**
-   * 字段 >= 值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值
-   */
-  public ExampleWrapper<T, I> ge(Fn<T, Object> fn, Object value) {
-    this.current.addCriterion(fn.toColumn() + " >=", value);
-    return this;
-  }
-
-  /**
-   * 字段 < 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   */
-  public ExampleWrapper<T, I> lt(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
-    return useCondition ? lt(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 < 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值
-   */
-  public ExampleWrapper<T, I> lt(boolean useCondition, Fn<T, Object> fn, Object value) {
-    return useCondition ? lt(fn, value) : this;
-  }
-
-  /**
-   * 字段 < 值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值
-   */
-  public ExampleWrapper<T, I> lt(Fn<T, Object> fn, Object value) {
-    this.current.addCriterion(fn.toColumn() + " <", value);
-    return this;
-  }
-
-  /**
-   * 字段 <= 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值
-   */
-  public ExampleWrapper<T, I> le(boolean useCondition, Fn<T, Object> fn, Object value) {
-    return useCondition ? le(fn, value) : this;
-  }
-
-  /**
-   * 字段 <= 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数
-   */
-  public ExampleWrapper<T, I> le(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
-    return useCondition ? le(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 <= 值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值
-   */
-  public ExampleWrapper<T, I> le(Fn<T, Object> fn, Object value) {
-    this.current.addCriterion(fn.toColumn() + " <=", value);
-    return this;
-  }
-
-  /**
-   * 字段 in (值集合)
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param values       值集合
-   */
-  @SuppressWarnings("rawtypes")
-  public ExampleWrapper<T, I> in(boolean useCondition, Fn<T, Object> fn, Iterable values) {
-    return useCondition ? in(fn, values) : this;
-  }
-
-  /**
-   * 字段 in (值集合)
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值集合构造函数
-   */
-  @SuppressWarnings("rawtypes")
-  public ExampleWrapper<T, I> in(boolean useCondition, Fn<T, Object> fn, Supplier<Iterable> supplier) {
-    return useCondition ? in(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 in (值集合)
-   *
-   * @param fn     字段对应的 get 方法引用
-   * @param values 值集合
-   */
-  @SuppressWarnings("rawtypes")
-  public ExampleWrapper<T, I> in(Fn<T, Object> fn, Iterable values) {
-    this.current.addCriterion(fn.toColumn() + " IN", values);
-    return this;
-  }
-
-  /**
-   * 字段 not in (值集合)
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param values       值集合
-   */
-  @SuppressWarnings("rawtypes")
-  public ExampleWrapper<T, I> notIn(boolean useCondition, Fn<T, Object> fn, Iterable values) {
-    return useCondition ? notIn(fn, values) : this;
-  }
-
-  /**
-   * 字段 not in (值集合)
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值集合构造函数
-   */
-  @SuppressWarnings("rawtypes")
-  public ExampleWrapper<T, I> notIn(boolean useCondition, Fn<T, Object> fn, Supplier<Iterable> supplier) {
-    return useCondition ? notIn(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 not in (值集合)
-   *
-   * @param fn     字段对应的 get 方法引用
-   * @param values 值集合
-   */
-  @SuppressWarnings("rawtypes")
-  public ExampleWrapper<T, I> notIn(Fn<T, Object> fn, Iterable values) {
-    this.current.addCriterion(fn.toColumn() + " NOT IN", values);
-    return this;
-  }
-
-  /**
-   * 字段 between value1 and value 2
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value1       值1
-   * @param value2       值2
-   */
-  public ExampleWrapper<T, I> between(boolean useCondition, Fn<T, Object> fn, Object value1, Object value2) {
-    return useCondition ? between(fn, value1, value2) : this;
-  }
-
-  /**
-   * 字段 between value1 and value 2
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier1    值1构造函数
-   * @param supplier2    值2构造函数
-   */
-  public ExampleWrapper<T, I> between(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier1, Supplier<Object> supplier2) {
-    return useCondition ? between(fn, supplier1.get(), supplier2.get()) : this;
-  }
-
-  /**
-   * 字段 between value1 and value 2
-   *
-   * @param fn     字段对应的 get 方法引用
-   * @param value1 值1
-   * @param value2 值2
-   */
-  public ExampleWrapper<T, I> between(Fn<T, Object> fn, Object value1, Object value2) {
-    this.current.addCriterion(fn.toColumn() + " BETWEEN", value1, value2);
-    return this;
-  }
-
-  /**
-   * 字段 not between value1 and value 2
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value1       值1
-   * @param value2       值2
-   */
-  public ExampleWrapper<T, I> notBetween(boolean useCondition, Fn<T, Object> fn, Object value1, Object value2) {
-    return useCondition ? notBetween(fn, value1, value2) : this;
-  }
-
-  /**
-   * 字段 not between value1 and value 2
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier1    值1构造函数
-   * @param supplier2    值2构造函数
-   */
-  public ExampleWrapper<T, I> notBetween(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier1, Supplier<Object> supplier2) {
-    return useCondition ? notBetween(fn, supplier1.get(), supplier2.get()) : this;
-  }
-
-  /**
-   * 字段 not between value1 and value 2
-   *
-   * @param fn     字段对应的 get 方法引用
-   * @param value1 值1
-   * @param value2 值2
-   */
-  public ExampleWrapper<T, I> notBetween(Fn<T, Object> fn, Object value1, Object value2) {
-    this.current.addCriterion(fn.toColumn() + " NOT BETWEEN", value1, value2);
-    return this;
-  }
-
-  /**
-   * 字段 like %值%
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值，两侧自动添加 %
-   */
-  public ExampleWrapper<T, I> contains(boolean useCondition, Fn<T, Object> fn, String value) {
-    return useCondition ? contains(fn, value) : this;
-  }
-
-  /**
-   * 字段 like %值%
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数，两侧自动添加 %
-   */
-  public ExampleWrapper<T, I> contains(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
-    return useCondition ? contains(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 like %值%
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值，两侧自动添加 %
-   */
-  public ExampleWrapper<T, I> contains(Fn<T, Object> fn, String value) {
-    this.current.addCriterion(fn.toColumn() + "  LIKE", "%" + value + "%");
-    return this;
-  }
-
-  /**
-   * 字段 like 值%，匹配 value 为前缀的值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值，右侧自动添加 %
-   */
-  public ExampleWrapper<T, I> startsWith(boolean useCondition, Fn<T, Object> fn, String value) {
-    return useCondition ? startsWith(fn, value) : this;
-  }
-
-  /**
-   * 字段 like 值%，匹配 value 为前缀的值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数，右侧自动添加 %
-   */
-  public ExampleWrapper<T, I> startsWith(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
-    return useCondition ? startsWith(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 like 值%，匹配 value 为前缀的值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值，右侧自动添加 %
-   */
-  public ExampleWrapper<T, I> startsWith(Fn<T, Object> fn, String value) {
-    this.current.addCriterion(fn.toColumn() + "  LIKE", value + "%");
-    return this;
-  }
-
-  /**
-   * 字段 like %值，匹配 value 为后缀的值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值，左侧自动添加 %
-   */
-  public ExampleWrapper<T, I> endsWith(boolean useCondition, Fn<T, Object> fn, String value) {
-    return useCondition ? endsWith(fn, value) : this;
-  }
-
-  /**
-   * 字段 like %值，匹配 value 为后缀的值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数，左侧自动添加 %
-   */
-  public ExampleWrapper<T, I> endsWith(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
-    return useCondition ? endsWith(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 like %值，匹配 value 为后缀的值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值，左侧自动添加 %
-   */
-  public ExampleWrapper<T, I> endsWith(Fn<T, Object> fn, String value) {
-    this.current.addCriterion(fn.toColumn() + "  LIKE", "%" + value);
-    return this;
-  }
-
-  /**
-   * 字段 like 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值，需要指定 '%'(多个), '_'(单个) 模糊匹配
-   */
-  public ExampleWrapper<T, I> like(boolean useCondition, Fn<T, Object> fn, String value) {
-    return useCondition ? like(fn, value) : this;
-  }
-
-  /**
-   * 字段 like 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数，需要指定 '%'(多个), '_'(单个) 模糊匹配
-   */
-  public ExampleWrapper<T, I> like(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
-    return useCondition ? like(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 like 值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值，需要指定 '%'(多个), '_'(单个) 模糊匹配
-   */
-  public ExampleWrapper<T, I> like(Fn<T, Object> fn, String value) {
-    this.current.addCriterion(fn.toColumn() + "  LIKE", value);
-    return this;
-  }
-
-  /**
-   * 字段 not like 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param value        值，需要指定 % 模糊匹配
-   */
-  public ExampleWrapper<T, I> notLike(boolean useCondition, Fn<T, Object> fn, String value) {
-    return useCondition ? notLike(fn, value) : this;
-  }
-
-  /**
-   * 字段 not like 值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param fn           字段对应的 get 方法引用
-   * @param supplier     值构造函数，需要指定 % 模糊匹配
-   */
-  public ExampleWrapper<T, I> notLike(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
-    return useCondition ? notLike(fn, supplier.get()) : this;
-  }
-
-  /**
-   * 字段 not like 值
-   *
-   * @param fn    字段对应的 get 方法引用
-   * @param value 值，需要指定 % 模糊匹配
-   */
-  public ExampleWrapper<T, I> notLike(Fn<T, Object> fn, String value) {
-    this.current.addCriterion(fn.toColumn() + "  NOT LIKE", value);
-    return this;
-  }
-
-  /**
-   * 添加任意条件，条件一定是后端使用的，需要自己防止 SQL 注入
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param condition    任意条件，例如 "length(countryname)<5"
-   */
-  public ExampleWrapper<T, I> anyCondition(boolean useCondition, String condition) {
-    return useCondition ? anyCondition(condition) : this;
-  }
-
-  /**
-   * 添加任意条件，条件一定是后端使用的，需要自己防止 SQL 注入
-   *
-   * @param condition 任意条件，例如 "length(countryname)<5"
-   */
-  public ExampleWrapper<T, I> anyCondition(String condition) {
-    this.current.andCondition(condition);
-    return this;
-  }
-
-  /**
-   * 手写左边条件，右边用value值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param condition    例如 "length(countryname)="
-   * @param value        例如 5
-   */
-  public ExampleWrapper<T, I> anyCondition(boolean useCondition, String condition, Object value) {
-    return useCondition ? anyCondition(condition, value) : this;
-  }
-
-  /**
-   * 手写左边条件，右边用value值
-   *
-   * @param useCondition 表达式条件, true 使用，false 不使用
-   * @param condition    例如 "length(countryname)="
-   * @param supplier     任意条件值的构造函数
-   */
-  public ExampleWrapper<T, I> anyCondition(boolean useCondition, String condition, Supplier<Object> supplier) {
-    return useCondition ? anyCondition(condition, supplier.get()) : this;
-  }
-
-  /**
-   * 手写左边条件，右边用value值
-   *
-   * @param condition 例如 "length(countryname)="
-   * @param value     例如 5
-   */
-  public ExampleWrapper<T, I> anyCondition(String condition, Object value) {
-    this.current.andCondition(condition, value);
-    return this;
-  }
-
-  /**
-   * 嵌套 or 查询，数组多个条件直接使用 or，单个条件中为 and
-   *
-   * @param orParts 条件块
-   */
-  @SafeVarargs
-  public final ExampleWrapper<T, I> or(Function<Example.OrCriteria<T>, Example.OrCriteria<T>>... orParts) {
-    if (orParts != null && orParts.length > 0) {
-      this.current.andOr(Arrays.stream(orParts).map(orPart -> orPart.apply(example.orPart())).collect(Collectors.toList()));
-    }
+  @Override
+  public ExampleWrapper<T, I> getSelf() {
     return this;
   }
 
@@ -865,15 +50,15 @@ public class ExampleWrapper<T, I extends Serializable> {
    * 根据当前条件删除
    */
   public int delete() {
-    return baseMapper.deleteByExample(example);
+    return exampleMapper.deleteByExample(super.example());
   }
 
   /**
    * 将符合当前查询条件的数据更新为 {@link #set(String)} 和 {@link #set(Fn, Object)} 设置的值
    */
   public int update() {
-    Assert.notEmpty(example.getSetValues(), "必须通过 set 方法设置更新的列和值");
-    return baseMapper.updateByExampleSetValues(example);
+    Assert.notEmpty(super.example().getSetValues(), "必须通过 set 方法设置更新的列和值");
+    return exampleMapper.updateByExampleSetValues(super.example());
   }
 
   /**
@@ -882,7 +67,7 @@ public class ExampleWrapper<T, I extends Serializable> {
    * @param t 要更新的值
    */
   public int update(T t) {
-    return baseMapper.updateByExample(t, example);
+    return exampleMapper.updateByExample(t, super.example());
   }
 
   /**
@@ -891,14 +76,14 @@ public class ExampleWrapper<T, I extends Serializable> {
    * @param t 要更新的值
    */
   public int updateSelective(T t) {
-    return baseMapper.updateByExampleSelective(t, example);
+    return exampleMapper.updateByExampleSelective(t, super.example());
   }
 
   /**
    * 根据当前查询条件查询
    */
   public List<T> list() {
-    return baseMapper.selectByExample(example);
+    return exampleMapper.selectByExample(super.example());
   }
 
   /**
@@ -912,14 +97,14 @@ public class ExampleWrapper<T, I extends Serializable> {
    * 根据当前查询条件查询出一个结果，当存在多个符合条件的结果时会抛出异常 {@link TooManyResultsException}
    */
   public Optional<T> one() {
-    return baseMapper.selectOneByExample(example);
+    return exampleMapper.selectOneByExample(super.example());
   }
 
   /**
    * 根据当前查询条件查询出第一个结果，通过 {@link RowBounds} 实现
    */
   public Optional<T> first() {
-    return baseMapper.selectByExample(example, new RowBounds(0, 1)).stream().findFirst();
+    return exampleMapper.selectByExample(super.example(), new RowBounds(0, 1)).stream().findFirst();
   }
 
   /**
@@ -928,14 +113,14 @@ public class ExampleWrapper<T, I extends Serializable> {
    * @param n 结果数
    */
   public List<T> top(int n) {
-    return baseMapper.selectByExample(example, new RowBounds(0, n));
+    return exampleMapper.selectByExample(super.example(), new RowBounds(0, n));
   }
 
   /**
    * 查询符合当前条件的结果数
    */
   public long count() {
-    return baseMapper.countByExample(example);
+    return exampleMapper.countByExample(super.example());
   }
 
 }

--- a/mapper/src/main/java/io/mybatis/mapper/wrapper/PureWrapperMapper.java
+++ b/mapper/src/main/java/io/mybatis/mapper/wrapper/PureWrapperMapper.java
@@ -1,0 +1,201 @@
+package io.mybatis.mapper.wrapper;
+
+
+import io.mybatis.mapper.fn.Fn;
+import io.mybatis.provider.Caching;
+import io.mybatis.provider.EntityColumn;
+import io.mybatis.provider.EntityInfoMapper;
+import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.exceptions.TooManyResultsException;
+import org.apache.ibatis.session.RowBounds;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * 扩展mapper
+ * <p>
+ *
+ * @author dyun
+ */
+public interface PureWrapperMapper<T, I extends Serializable> extends EntityInfoMapper<T> {
+
+  /**
+   * 获取 Wrapper 对象
+   *
+   * @return Wrapper 对象
+   */
+  default Wrapper<T> sql() {
+    return new Wrapper<>();
+  }
+
+  /**
+   * 获取 Wrapper 对象 并 Criteria 条件
+   *
+   * @return Criteria 对象
+   */
+  default Wrapper.Criteria<T> where() {
+    return new Wrapper<T>().where();
+  }
+
+  /**
+   * 根据 ids 批量查询
+   *
+   * @param ids 主键列表
+   * @return 实体列表
+   */
+  default List<T> selectByIds(I... ids) {
+    String idColumn = entityTable().idColumns().stream().findFirst().map(EntityColumn::column).orElseThrow(RuntimeException::new);
+    return selectList(where().in(Fn.column(entityClass(), idColumn), Stream.of(ids).collect(Collectors.toList())).build());
+  }
+
+  /**
+   * 根据 ids 批量删除
+   *
+   * @param ids 主键列表
+   * @return 1成功，0失败
+   */
+  default int deleteByIds(I... ids) {
+    String idColumn = entityTable().idColumns().stream().findFirst().map(EntityColumn::column).orElseThrow(RuntimeException::new);
+    return delete(where().in(Fn.column(entityClass(), idColumn), Stream.of(ids).collect(Collectors.toList())).build());
+  }
+
+  /*
+   * ========================================rename wrapper method for pure========================================
+   */
+
+  /**
+   * 保存实体（字段不为空）
+   *
+   * @param entity 实体类
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @InsertProvider(type = WrapperProvider.class, method = WrapperProvider.insertInWrapper)
+  int insert(T entity);
+
+  /**
+   * 保存实体（字段可为空）
+   *
+   * @param entity 实体类
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @InsertProvider(type = WrapperProvider.class, method = WrapperProvider.insertNullableInWrapper)
+  int insertNullable(T entity);
+
+  /**
+   * 根据主键更新实体（字段不为空）
+   *
+   * @param entity 实体类
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @UpdateProvider(type = WrapperProvider.class, method = WrapperProvider.updateByIdInWrapper)
+  int updateById(T entity);
+
+  /**
+   * 根据主键更新实体（字段可为空）
+   *
+   * @param entity 实体类
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @UpdateProvider(type = WrapperProvider.class, method = WrapperProvider.updateNullableByIdInWrapper)
+  int updateNullableById(T entity);
+
+  /**
+   * 根据主键删除
+   *
+   * @param id 主键
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @DeleteProvider(type = WrapperProvider.class, method = WrapperProvider.deleteByIdInWrapper)
+  int deleteById(I id);
+
+  /**
+   * 根据主键查询实体
+   *
+   * @param id 主键
+   * @return 实体
+   */
+  @Lang(Caching.class)
+  @SelectProvider(type = WrapperProvider.class, method = WrapperProvider.selectByIdInWrapper)
+  Optional<T> selectById(I id);
+
+  /**
+   * 根据 Wrapper 条件批量更新实体信息
+   *
+   * @param entity  实体类
+   * @param wrapper 条件
+   * @return 大于等于1成功，0失败
+   */
+  @Lang(Caching.class)
+  @UpdateProvider(type = WrapperProvider.class, method = WrapperProvider.updateByWrapper)
+  int update(@Param("entity") T entity, @Param("wrapper") Wrapper<T> wrapper);
+
+  /**
+   * 根据 Wrapper 删除
+   *
+   * @param wrapper 条件
+   * @return 大于等于1成功，0失败
+   */
+  @Lang(Caching.class)
+  @DeleteProvider(type = WrapperProvider.class, method = WrapperProvider.deleteByWrapper)
+  int delete(Wrapper<T> wrapper);
+
+  /**
+   * 根据 Wrapper 条件批量查询
+   *
+   * @param wrapper 条件
+   * @return 实体列表
+   */
+  @Lang(Caching.class)
+  @SelectProvider(type = WrapperProvider.class, method = WrapperProvider.selectByWrapper)
+  List<T> selectList(Wrapper<T> wrapper);
+
+  /**
+   * 根据 Wrapper 条件批量查询
+   *
+   * @param rowBounds 分页信息
+   * @param wrapper   条件
+   * @return 实体列表
+   */
+  List<T> selectList(RowBounds rowBounds, Wrapper<T> wrapper);
+
+  /**
+   * 根据 Wrapper 条件查询单个实体
+   *
+   * @param wrapper @param wrapper 条件
+   * @return 单个实体，查询结果由多条时报错
+   * @throws TooManyResultsException exception
+   */
+  @Lang(Caching.class)
+  @SelectProvider(type = WrapperProvider.class, method = WrapperProvider.selectByWrapper)
+  Optional<T> selectOneThrow(Wrapper<T> wrapper) throws TooManyResultsException;
+
+  /**
+   * 根据 Wrapper 条件查询单个实体
+   *
+   * @param wrapper 条件
+   * @return 单个实体
+   */
+  default Optional<T> selectOne(Wrapper<T> wrapper) {
+    return selectList(new RowBounds(0, 1), wrapper).stream().findFirst();
+  }
+
+  /**
+   * 根据 Wrapper 条件查询总数
+   *
+   * @param wrapper 条件
+   * @return 总数
+   */
+  @Lang(Caching.class)
+  @SelectProvider(type = WrapperProvider.class, method = WrapperProvider.countByWrapper)
+  long count(Wrapper<T> wrapper);
+
+}

--- a/mapper/src/main/java/io/mybatis/mapper/wrapper/Wrapper.java
+++ b/mapper/src/main/java/io/mybatis/mapper/wrapper/Wrapper.java
@@ -1,0 +1,1419 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mybatis.mapper.wrapper;
+
+import io.mybatis.mapper.fn.Fn;
+import io.mybatis.provider.EntityColumn;
+import io.mybatis.provider.EntityTable;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.stream.Collectors;
+
+import static io.mybatis.provider.EntityTable.DELIMITER;
+
+/**
+ * 通用的 Wrapper 查询对象
+ *
+ * @author dyun
+ */
+public class Wrapper<T> {
+  /**
+   * 排序字段
+   */
+  private String            orderByClause;
+  /**
+   * 是否使用 distinct
+   */
+  private boolean           distinct;
+  /**
+   * 是否允许 更新实体类字段可为空
+   */
+  private boolean           updateNullable;
+  /**
+   * 指定查询列
+   */
+  private String            selectColumns;
+  /**
+   * 指定查询列，不带 column As Alias 别名
+   */
+  private String            simpleSelectColumns;
+  /**
+   * 起始 SQL，添加到 SQL 前，注意防止 SQL 注入
+   */
+  private String            startSql;
+  /**
+   * 结尾 SQL，添加到 SQL 最后，注意防止 SQL 注入
+   */
+  private String            endSql;
+  /**
+   * 多组条件通过 OR 连接
+   */
+  private List<Criteria<T>> oredCriteria;
+  /**
+   * 最后一个条件, 不参与多组
+   */
+  private Criteria<T>       lastCriteria;
+  /**
+   * 设置 update 时的 set 字段
+   */
+  private List<Criterion>   setValues;
+
+  /**
+   * 默认构造方法，不允许Wrapper查询条件为空，不能操作全库
+   */
+  public Wrapper() {
+    oredCriteria = new ArrayList<>();
+    setValues = new ArrayList<>();
+  }
+
+  /**
+   * or 条件
+   *
+   * @param criteria 条件
+   */
+  public void or(Criteria<T> criteria) {
+    oredCriteria.add(criteria);
+  }
+
+  /**
+   * 创建一个 or条件片段（不追加到当前Wrapper）
+   *
+   * @return 条件
+   */
+  public OrCriteria<T> orPart() {
+    return new OrCriteria<>();
+  }
+
+  public Criteria<T> createCriteriaInternal() {
+    return new Criteria<>(this);
+  }
+
+  /**
+   * 清除所有设置
+   */
+  public void clear() {
+    oredCriteria.clear();
+    setValues.clear();
+    orderByClause = null;
+    distinct = false;
+    updateNullable = false;
+    selectColumns = null;
+    simpleSelectColumns = null;
+    startSql = null;
+    endSql = null;
+    lastCriteria = null;
+  }
+
+  /**
+   * 清除条件，可重用
+   */
+  public Criteria<T> clean() {
+    this.clear();
+    return this.where();
+  }
+
+  /**
+   * 创建一组条件，第一次调用时添加到默认条件中
+   */
+  public Criteria<T> where() {
+    Criteria<T> criteria = createCriteriaInternal();
+    if (this.oredCriteria.size() == 0) {
+      this.oredCriteria.add(criteria);
+    }
+    return criteria;
+  }
+
+  /**
+   * 指定查询列
+   *
+   * @param selectColumns 查询列
+   */
+  public Wrapper<T> select(String selectColumns) {
+    this.selectColumns = selectColumns;
+    return this;
+  }
+
+  /**
+   * 设置简单查询列，不能带别名
+   *
+   * @param simpleSelectColumns 简单查询列
+   */
+  public Wrapper<T> selectSimple(String simpleSelectColumns) {
+    this.simpleSelectColumns = simpleSelectColumns;
+    return this;
+  }
+
+  /**
+   * 指定查询列，多次调用会覆盖，设置时会清除 {@link #exclude}
+   *
+   * @param fns 方法引用
+   */
+  @SafeVarargs
+  public final Wrapper<T> select(Fn<T, Object>... fns) {
+    selectColumns = "";
+    simpleSelectColumns = "";
+    if (fns == null || fns.length == 0) {
+      return this;
+    }
+    select(Arrays.stream(fns).map(Wrapper::toEntityColumn).collect(Collectors.toList()));
+    return this;
+  }
+
+  /**
+   * 指定查询列，多次调用会覆盖，设置时会清除 {@link #exclude}
+   *
+   * @param columns 查询列
+   */
+  private void select(List<EntityColumn> columns) {
+    StringBuilder sb = new StringBuilder(columns.size() * 16);
+    StringBuilder simple = new StringBuilder(columns.size() * 16);
+    for (EntityColumn entityColumn : columns) {
+      String column = entityColumn.column();
+      String field = entityColumn.field().getName();
+      if (sb.length() != 0) {
+        sb.append(",");
+      }
+      if (simple.length() != 0) {
+        simple.append(",");
+      }
+      //fix 如果有设置 autoResultMap 就不能有 AS
+      if (column.equals(field) || entityColumn.entityTable().useResultMaps()) {
+        sb.append(column);
+        simple.append(column);
+      } else {
+        Matcher matcher = DELIMITER.matcher(column);
+        //eg: mysql `order` == field order | sqlserver [order] == field order
+        simple.append(column);
+        if (matcher.find() && field.equals(matcher.group(1))) {
+          sb.append(column);
+        } else {
+          sb.append(column).append(" AS ").append(field);
+        }
+      }
+    }
+    selectColumns = sb.toString();
+    simpleSelectColumns = simple.toString();
+  }
+
+  /**
+   * 排除指定的查询列，设置时会清除 {@link #selectColumns}
+   *
+   * @param fns 方法引用
+   */
+  @SafeVarargs
+  public final Wrapper<T> exclude(Fn<T, Object>... fns) {
+    selectColumns = "";
+    simpleSelectColumns = "";
+    if (fns == null || fns.length == 0) {
+      return this;
+    }
+    //获取对应的实体类
+    EntityTable table = toEntityColumn(fns[0]).entityTable();
+    //排除列
+    Set<String> excludeColumnSet = Arrays.stream(fns).map(Wrapper::toColumn).collect(Collectors.toSet());
+    //设置
+    select(table.selectColumns().stream()
+        .filter(c -> !excludeColumnSet.contains(c.column())).collect(Collectors.toList()));
+    return this;
+  }
+
+  /**
+   * 获取查询列
+   *
+   * @return 查询列
+   */
+  public String getSelectColumns() {
+    return selectColumns;
+  }
+
+  /**
+   * 获取查询列，不带 column As Alias 别名
+   *
+   * @return 查询列
+   */
+  public String getSimpleSelectColumns() {
+    return simpleSelectColumns;
+  }
+
+  /**
+   * 获取起始 SQL
+   *
+   * @return 起始 SQL
+   */
+  public String getStartSql() {
+    return startSql;
+  }
+
+  /**
+   * 设置起始 SQL
+   *
+   * @param startSql 起始 SQL，添加到 SQL 前，注意防止 SQL 注入
+   */
+  public Wrapper<T> startSql(String startSql) {
+    this.startSql = startSql;
+    return this;
+  }
+
+  /**
+   * 获取结尾 SQL
+   *
+   * @return 结尾 SQL
+   */
+  public String getEndSql() {
+    return endSql;
+  }
+
+  /**
+   * 设置结尾 SQL
+   *
+   * @param endSql 结尾 SQL，添加到 SQL 最后，注意防止 SQL 注入
+   */
+  public Wrapper<T> endSql(String endSql) {
+    this.endSql = endSql;
+    return this;
+  }
+
+  /**
+   * 获取排序列
+   *
+   * @return 排序列
+   */
+  public String getOrderByClause() {
+    return orderByClause;
+  }
+
+  /**
+   * 设置排序列
+   *
+   * @param orderByClause 排序列
+   */
+  public Wrapper<T> setOrderByClause(String orderByClause) {
+    this.orderByClause = orderByClause;
+    return this;
+  }
+
+  /**
+   * 获取所有条件
+   *
+   * @return 条件
+   */
+  public List<Criteria<T>> getOredCriteria() {
+    return oredCriteria;
+  }
+
+  /**
+   * 获取最后一个条件
+   *
+   * @return 条件
+   */
+  public Criteria<T> getlastCriteria() {
+    return lastCriteria;
+  }
+
+  /**
+   * 是否使用 distince
+   *
+   * @return distince
+   */
+  public boolean isDistinct() {
+    return distinct;
+  }
+
+  /**
+   * 设置 distince
+   *
+   * @param distinct true启用，false不使用
+   */
+  public Wrapper<T> distinct(boolean distinct) {
+    this.distinct = distinct;
+    return this;
+  }
+
+  /**
+   * 是否 更新实体类字段可为空
+   *
+   * @return distince
+   */
+  public boolean isUpdateNullable() {
+    return updateNullable;
+  }
+
+  /**
+   * 设置 更新实体类字段可为空
+   *
+   * @param updateNullable true启用，false不使用
+   */
+  public Wrapper<T> updateNullable(boolean updateNullable) {
+    this.updateNullable = updateNullable;
+    return this;
+  }
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param setSql "column = value"
+   */
+  public Wrapper<T> set(String setSql) {
+    this.setValues.add(new Criterion(setSql));
+    return this;
+  }
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param fn    字段
+   * @param value 值
+   */
+  public Wrapper<T> set(Fn<T, Object> fn, Object value) {
+    this.setValues.add(new Criterion(toColumn(fn), value));
+    return this;
+  }
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param useSet 表达式条件, true 使用，false 不使用
+   * @param setSql "column = value"
+   */
+  public Wrapper<T> set(boolean useSet, String setSql) {
+    return useSet ? set(setSql) : this;
+  }
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param useSet 表达式条件, true 使用，false 不使用
+   * @param fn     字段
+   * @param value  值
+   */
+  public Wrapper<T> set(boolean useSet, Fn<T, Object> fn, Object value) {
+    return useSet ? set(fn, value) : this;
+  }
+
+  /**
+   * 设置更新字段和值
+   *
+   * @param useSet   表达式条件, true 使用，false 不使用
+   * @param fn       字段
+   * @param supplier 值构造函数
+   */
+  public Wrapper<T> set(boolean useSet, Fn<T, Object> fn, Supplier<Object> supplier) {
+    return useSet ? set(fn, supplier.get()) : this;
+  }
+
+  /**
+   * 获取 set 值
+   */
+  public List<Criterion> getSetValues() {
+    return setValues;
+  }
+
+  /**
+   * criteria抽象类
+   *
+   * @param <T> 实体类类型
+   * @param <E> 实现类类型
+   */
+  public static abstract class GeneratedCriteria<T, E> {
+    public List<Criterion> criteria;
+
+    /**
+     * 获取实现类
+     */
+    public abstract E getSelf();
+
+    protected GeneratedCriteria() {
+      super();
+      this.criteria = new ArrayList<>();
+    }
+
+    public List<Criterion> getCriteria() {
+      return criteria;
+    }
+
+    public boolean isValid() {
+      return criteria.size() > 0;
+    }
+
+    private String column(Fn<T, Object> fn) {
+      return Wrapper.toColumn(fn);
+    }
+
+    /**
+     * 添加任意条件，条件一定是后端使用的，需要自己防止 SQL 注入
+     *
+     * @param condition 任意条件，例如 "length(countryname)<5"
+     */
+    public E apply(String condition) {
+      if (condition == null) {
+        throw new RuntimeException("Value for condition cannot be null");
+      }
+      criteria.add(new Criterion(condition));
+      return getSelf();
+    }
+
+    /**
+     * 手写左边条件，右边用value值
+     *
+     * @param condition 例如 "length(countryname)="
+     * @param value     例如 5
+     */
+    public E apply(String condition, Object value) {
+      if (value == null) {
+        throw new RuntimeException("Value for " + condition + " cannot be null");
+      }
+      criteria.add(new Criterion(condition, value));
+      return getSelf();
+    }
+
+    /**
+     * 添加任意条件，条件一定是后端使用的，需要自己防止 SQL 注入
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param condition    任意条件，例如 "length(countryname)<5"
+     */
+    public E apply(boolean useCondition, String condition) {
+      return useCondition ? apply(condition) : getSelf();
+    }
+
+    /**
+     * 手写左边条件，右边用value值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param condition    例如 "length(countryname)="
+     * @param value        例如 5
+     */
+    public E apply(boolean useCondition, String condition, Object value) {
+      return useCondition ? apply(condition, value) : getSelf();
+    }
+
+    /**
+     * 手写左边条件，右边用value值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param condition    例如 "length(countryname)="
+     * @param supplier     任意条件值的构造函数
+     */
+    public E apply(boolean useCondition, String condition, Supplier<Object> supplier) {
+      return useCondition ? apply(condition, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 用于between语句， 字段 between value1 and value 2
+     *
+     * @param condition 表达式条件, true 使用，false 不使用
+     * @param value1    值1
+     * @param value2    值2
+     */
+    private E apply(String condition, Object value1, Object value2) {
+      if (value1 == null || value2 == null) {
+        throw new RuntimeException("Between values for " + condition + " cannot be null");
+      }
+      criteria.add(new Criterion(condition, value1, value2));
+      return getSelf();
+    }
+
+    /**
+     * 指定字段为 null
+     *
+     * @param fn 字段对应的 get 方法引用
+     */
+    public E isNull(Fn<T, Object> fn) {
+      apply(column(fn) + " IS NULL");
+      return getSelf();
+    }
+
+    /**
+     * 指定字段为 null
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     */
+    public E isNull(boolean useCondition, Fn<T, Object> fn) {
+      return useCondition ? isNull(fn) : getSelf();
+    }
+
+    /**
+     * 指定字段不为 null
+     *
+     * @param fn 字段对应的 get 方法引用
+     */
+    public E isNotNull(Fn<T, Object> fn) {
+      apply((column(fn) + " IS NOT NULL"));
+      return getSelf();
+    }
+
+    /**
+     * 指定字段不为 null
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     */
+    public E isNotNull(boolean useCondition, Fn<T, Object> fn) {
+      return useCondition ? isNotNull(fn) : getSelf();
+    }
+
+    /**
+     * 字段 = 值
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值
+     */
+    public E eq(Fn<T, Object> fn, Object value) {
+      apply(column(fn) + " =", value);
+      return getSelf();
+    }
+
+    /**
+     * 字段 = 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值
+     */
+    public E eq(boolean useCondition, Fn<T, Object> fn, Object value) {
+      return useCondition ? eq(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 = 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值构造函数
+     */
+    public E eq(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+      return useCondition ? eq(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 != 值
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值
+     */
+    public E ne(Fn<T, Object> fn, Object value) {
+      apply(column(fn) + " <>", value);
+      return getSelf();
+    }
+
+    /**
+     * 字段 != 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值
+     */
+    public E ne(boolean useCondition, Fn<T, Object> fn, Object value) {
+      return useCondition ? ne(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 != 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值构造函数
+     */
+    public E ne(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+      return useCondition ? ne(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 > 值
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值
+     */
+    public E gt(Fn<T, Object> fn, Object value) {
+      apply(column(fn) + " >", value);
+      return getSelf();
+    }
+
+    /**
+     * 字段 > 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值
+     */
+    public E gt(boolean useCondition, Fn<T, Object> fn, Object value) {
+      return useCondition ? gt(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 > 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值构造函数
+     */
+    public E gt(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+      return useCondition ? gt(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 >= 值
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值
+     */
+    public E ge(Fn<T, Object> fn, Object value) {
+      apply(column(fn) + " >=", value);
+      return getSelf();
+    }
+
+    /**
+     * 字段 >= 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值
+     */
+    public E ge(boolean useCondition, Fn<T, Object> fn, Object value) {
+      return useCondition ? ge(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 >= 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值构造函数
+     */
+    public E ge(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+      return useCondition ? ge(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 < 值
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值
+     */
+    public E lt(Fn<T, Object> fn, Object value) {
+      apply(column(fn) + " <", value);
+      return getSelf();
+    }
+
+    /**
+     * 字段 < 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值
+     */
+    public E lt(boolean useCondition, Fn<T, Object> fn, Object value) {
+      return useCondition ? lt(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 < 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     */
+    public E lt(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+      return useCondition ? lt(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 <= 值
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值
+     */
+    public E le(Fn<T, Object> fn, Object value) {
+      apply(column(fn) + " <=", value);
+      return getSelf();
+    }
+
+    /**
+     * 字段 <= 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值
+     */
+    public E le(boolean useCondition, Fn<T, Object> fn, Object value) {
+      return useCondition ? le(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 <= 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值构造函数
+     */
+    public E le(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier) {
+      return useCondition ? le(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 in (值集合)
+     *
+     * @param fn     字段对应的 get 方法引用
+     * @param values 值集合
+     */
+    @SuppressWarnings("rawtypes")
+    public E in(Fn<T, Object> fn, Iterable values) {
+      apply(column(fn) + " IN", values);
+      return getSelf();
+    }
+
+    /**
+     * 字段 in (值集合)
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param values       值集合
+     */
+    @SuppressWarnings("rawtypes")
+    public E in(boolean useCondition, Fn<T, Object> fn, Iterable values) {
+      return useCondition ? in(fn, values) : getSelf();
+    }
+
+    /**
+     * 字段 in (值集合)
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值集合构造函数
+     */
+    @SuppressWarnings("rawtypes")
+    public E in(boolean useCondition, Fn<T, Object> fn, Supplier<Iterable> supplier) {
+      return useCondition ? in(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 not in (值集合)
+     *
+     * @param fn     字段对应的 get 方法引用
+     * @param values 值集合
+     */
+    @SuppressWarnings("rawtypes")
+    public E notIn(Fn<T, Object> fn, Iterable values) {
+      apply(column(fn) + " NOT IN", values);
+      return getSelf();
+    }
+
+    /**
+     * 字段 not in (值集合)
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param values       值集合
+     */
+    @SuppressWarnings("rawtypes")
+    public E notIn(boolean useCondition, Fn<T, Object> fn, Iterable values) {
+      return useCondition ? notIn(fn, values) : getSelf();
+    }
+
+    /**
+     * 字段 not in (值集合)
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值集合构造函数
+     */
+    @SuppressWarnings("rawtypes")
+    public E notIn(boolean useCondition, Fn<T, Object> fn, Supplier<Iterable> supplier) {
+      return useCondition ? notIn(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 between value1 and value 2
+     *
+     * @param fn     字段对应的 get 方法引用
+     * @param value1 值1
+     * @param value2 值2
+     */
+    public E between(Fn<T, Object> fn, Object value1, Object value2) {
+      apply(column(fn) + " BETWEEN", value1, value2);
+      return getSelf();
+    }
+
+    /**
+     * 字段 between value1 and value 2
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value1       值1
+     * @param value2       值2
+     */
+    public E between(boolean useCondition, Fn<T, Object> fn, Object value1, Object value2) {
+      return useCondition ? between(fn, value1, value2) : getSelf();
+    }
+
+    /**
+     * 字段 between value1 and value 2
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier1    值1构造函数
+     * @param supplier2    值2构造函数
+     */
+    public E between(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier1, Supplier<Object> supplier2) {
+      return useCondition ? between(fn, supplier1.get(), supplier2.get()) : getSelf();
+    }
+
+    /**
+     * 字段 not between value1 and value 2
+     *
+     * @param fn     字段对应的 get 方法引用
+     * @param value1 值1
+     * @param value2 值2
+     */
+    public E notBetween(Fn<T, Object> fn, Object value1, Object value2) {
+      apply(column(fn) + " NOT BETWEEN", value1, value2);
+      return getSelf();
+    }
+
+    /**
+     * 字段 not between value1 and value 2
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value1       值1
+     * @param value2       值2
+     */
+    public E notBetween(boolean useCondition, Fn<T, Object> fn, Object value1, Object value2) {
+      return useCondition ? notBetween(fn, value1, value2) : getSelf();
+    }
+
+    /**
+     * 字段 not between value1 and value 2
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier1    值1构造函数
+     * @param supplier2    值2构造函数
+     */
+    public E notBetween(boolean useCondition, Fn<T, Object> fn, Supplier<Object> supplier1, Supplier<Object> supplier2) {
+      return useCondition ? notBetween(fn, supplier1.get(), supplier2.get()) : getSelf();
+    }
+
+    /**
+     * 字段 like %值%
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值，两侧自动添加 %
+     */
+    public E like(Fn<T, Object> fn, String value) {
+      apply(column(fn) + " LIKE", "%" + value + "%");
+      return getSelf();
+    }
+
+    /**
+     * 字段 like %值%
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值，两侧自动添加 %
+     */
+    public E like(boolean useCondition, Fn<T, Object> fn, String value) {
+      return useCondition ? like(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 like %值%
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值构造函数，两侧自动添加 %
+     */
+    public E like(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
+      return useCondition ? like(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 not like 值
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值，两侧自动添加 %
+     */
+    public E notLike(Fn<T, Object> fn, String value) {
+      apply(column(fn) + " NOT LIKE", "%" + value + "%");
+      return getSelf();
+    }
+
+    /**
+     * 字段 not like 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值，两侧自动添加 %
+     */
+    public E notLike(boolean useCondition, Fn<T, Object> fn, String value) {
+      return useCondition ? notLike(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 not like 值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值构造函数，两侧自动添加 %
+     */
+    public E notLike(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
+      return useCondition ? notLike(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 like 值%，匹配 value 为前缀的值
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值，右侧自动添加 %
+     */
+    public E startsWith(Fn<T, Object> fn, String value) {
+      apply(column(fn) + " LIKE", value + "%");
+      return getSelf();
+    }
+
+    /**
+     * 字段 like 值%，匹配 value 为前缀的值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值，右侧自动添加 %
+     */
+    public E startsWith(boolean useCondition, Fn<T, Object> fn, String value) {
+      return useCondition ? startsWith(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 like 值%，匹配 value 为前缀的值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值构造函数，右侧自动添加 %
+     */
+    public E startsWith(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
+      return useCondition ? startsWith(fn, supplier.get()) : getSelf();
+    }
+
+    /**
+     * 字段 like %值，匹配 value 为后缀的值
+     *
+     * @param fn    字段对应的 get 方法引用
+     * @param value 值，左侧自动添加 %
+     */
+    public E endsWith(Fn<T, Object> fn, String value) {
+      apply(column(fn) + " LIKE", "%" + value);
+      return getSelf();
+    }
+
+    /**
+     * 字段 like %值，匹配 value 为后缀的值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param value        值，左侧自动添加 %
+     */
+    public E endsWith(boolean useCondition, Fn<T, Object> fn, String value) {
+      return useCondition ? endsWith(fn, value) : getSelf();
+    }
+
+    /**
+     * 字段 like %值，匹配 value 为后缀的值
+     *
+     * @param useCondition 表达式条件, true 使用，false 不使用
+     * @param fn           字段对应的 get 方法引用
+     * @param supplier     值构造函数，左侧自动添加 %
+     */
+    public E endsWith(boolean useCondition, Fn<T, Object> fn, Supplier<String> supplier) {
+      return useCondition ? endsWith(fn, supplier.get()) : getSelf();
+    }
+  }
+
+  public static class Criteria<T> extends GeneratedCriteria<T, Criteria<T>> {
+    private Wrapper<T> currentWrapper;
+
+    public Criteria() {
+      super();
+    }
+
+    public Criteria(Wrapper<T> wrapper) {
+      super();
+      this.currentWrapper = wrapper;
+    }
+
+    @Override
+    public Criteria<T> getSelf() {
+      return this;
+    }
+
+    /**
+     * 增加 AND 条件, 条件内的如果有多组条件用 OR 连接
+     */
+    @SafeVarargs
+    public final Criteria<T> and(OrCriteria<T> orCriteria1, OrCriteria<T> orCriteria2, OrCriteria<T>... orCriterias) {
+      List<OrCriteria<T>> orCriteriaList = new ArrayList<>(orCriterias != null ? orCriterias.length + 2 : 2);
+      orCriteriaList.add(orCriteria1);
+      orCriteriaList.add(orCriteria2);
+      if (orCriterias != null) {
+        orCriteriaList.addAll(Arrays.asList(orCriterias));
+      }
+      return and(orCriteriaList);
+    }
+
+    /**
+     * 增加 AND 条件, 条件内的如果有多组条件用 OR 连接
+     */
+    public Criteria<T> and(List<OrCriteria<T>> orCriteriaList) {
+      super.criteria.add(new Criterion(null, orCriteriaList));
+      return this;
+    }
+
+    /**
+     * 增加 AND 条件, 条件内的如果有多组条件用 OR 连接
+     *
+     * @param orParts 条件块
+     */
+    @SafeVarargs
+    public final Criteria<T> and(Function<OrCriteria<T>, OrCriteria<T>>... orParts) {
+      if (orParts != null && orParts.length > 0) {
+        and(Arrays.stream(orParts).map(orPart -> orPart.apply(new Wrapper<T>().orPart())).collect(Collectors.toList()));
+      }
+      return this;
+    }
+
+    /**
+     * or 一组条件
+     *
+     * @return 条件
+     */
+    public Criteria<T> or() {
+      Criteria<T> criteria = currentWrapper.createCriteriaInternal();
+      currentWrapper.oredCriteria.add(criteria);
+      return criteria;
+    }
+
+    /**
+     * 最后一组条件
+     * <p>
+     * 重复调用将覆盖
+     *
+     * @return 条件
+     */
+    public Criteria<T> last() {
+      Criteria<T> criteria = currentWrapper.createCriteriaInternal();
+      currentWrapper.lastCriteria = criteria;
+      return criteria;
+    }
+
+    /**
+     * 通过方法引用方式设置排序字段
+     *
+     * @param fn    排序列的方法引用
+     * @param order 排序方式
+     * @return Wrapper
+     */
+    public Criteria<T> orderBy(Fn<T, Object> fn, Order order) {
+      if (currentWrapper.orderByClause == null) {
+        currentWrapper.orderByClause = "";
+      } else {
+        currentWrapper.orderByClause += ", ";
+      }
+      currentWrapper.orderByClause += toColumn(fn) + " " + order;
+      return this;
+    }
+
+    /**
+     * 用于一些非常规的排序 或 简单的字符串形式的排序 <br>
+     * 本方法 和 Wrapper.setOrderByClause 方法的区别是 <strong>本方法不会覆盖已有的排序内容</strong> <br>
+     * eg：  ORDER BY status = 5 DESC  即将 status = 5 的放在最前面<br>
+     * 此时入参为：<pre><code>Wrapper.orderBy("status = 5 DESC")</code></pre>
+     *
+     * @param orderByCondition 字符串排序表达式
+     * @return Wrapper
+     */
+    public Criteria<T> orderBy(String orderByCondition) {
+      if (orderByCondition != null && orderByCondition.length() > 0) {
+        if (currentWrapper.orderByClause == null) {
+          currentWrapper.orderByClause = "";
+        } else {
+          currentWrapper.orderByClause += ", ";
+        }
+        currentWrapper.orderByClause += orderByCondition;
+      }
+      return this;
+    }
+
+
+    /**
+     * 用于一些特殊的非常规的排序，排序字符串需要通过一些函数或者方法来构造出来<br>
+     * eg：  ORDER BY FIELD(id,3,1,2) 即将 id 按照 3，1，2 的顺序排序<br>
+     * 此时入参为：<pre><code>Wrapper.orderBy(()-> {
+     * return Stream.of(3,1,2)
+     *              .map(Objects::toString)
+     *              .collect(Collectors.joining("," , "FIELD( id ," , ")"));
+     * })</code></pre>
+     *
+     * @param orderByCondition 字符串排序表达式
+     * @return Wrapper
+     */
+    public Criteria<T> orderBy(Supplier<String> orderByCondition) {
+      return orderBy(orderByCondition.get());
+    }
+
+    /**
+     * 支持使用字符串形式来设置 order by，用以支持一些特殊的排序方案
+     *
+     * @param useOrderBy       条件表达式，true使用，false不使用 字符串排序
+     * @param orderByCondition 排序字符串构造方法，比如通过数组集合循环拼接等
+     * @return Wrapper
+     */
+    public Criteria<T> orderBy(boolean useOrderBy, Supplier<String> orderByCondition) {
+      return useOrderBy ? orderBy(orderByCondition) : this;
+    }
+
+    /**
+     * 通过方法引用方式设置排序字段，升序排序
+     *
+     * @param fns 排序列的方法引用
+     * @return Wrapper
+     */
+    @SafeVarargs
+    public final Criteria<T> orderByAsc(Fn<T, Object>... fns) {
+      if (fns != null && fns.length > 0) {
+        for (Fn<T, Object> fn : fns) {
+          orderBy(fn, Order.ASC);
+        }
+      }
+      return this;
+    }
+
+    /**
+     * 通过方法引用方式设置排序字段，降序排序
+     *
+     * @param fns 排序列的方法引用
+     * @return Wrapper
+     */
+    @SafeVarargs
+    public final Criteria<T> orderByDesc(Fn<T, Object>... fns) {
+      if (fns != null && fns.length > 0) {
+        for (Fn<T, Object> fn : fns) {
+          orderBy(fn, Order.DESC);
+        }
+      }
+      return this;
+    }
+
+    /**
+     * 获取当前wrapper
+     */
+    public Wrapper<T> build() {
+      return currentWrapper;
+    }
+
+    /**
+     * 执行消费
+     */
+    public <R> R execute(Function<Wrapper<T>, R> method) {
+      return method.apply(currentWrapper);
+    }
+
+    /**
+     * 执行消费
+     */
+    public <U, R> R execute(U entity, BiFunction<U, Wrapper<T>, R> method) {
+      return method.apply(entity, currentWrapper);
+    }
+  }
+
+  public static class OrCriteria<T> extends GeneratedCriteria<T, OrCriteria<T>> {
+    public OrCriteria() {
+      super();
+    }
+
+    @Override
+    public OrCriteria<T> getSelf() {
+      return this;
+    }
+  }
+
+  public static class Criterion {
+    private final String condition;
+
+    private Object value;
+
+    private Object secondValue;
+
+    private boolean noValue;
+
+    private boolean singleValue;
+
+    private boolean betweenValue;
+
+    private boolean listValue;
+
+    private boolean orValue;
+
+    public Criterion(String condition) {
+      super();
+      this.condition = condition;
+      this.noValue = true;
+    }
+
+    public Criterion(String condition, Object value) {
+      this(condition, value, null);
+    }
+
+    public Criterion(String condition, Object value, String typeHandler) {
+      super();
+      this.condition = condition;
+      this.value = value;
+      if (value instanceof Collection<?>) {
+        if (condition != null) {
+          this.listValue = true;
+        } else {
+          this.orValue = true;
+        }
+      } else {
+        this.singleValue = true;
+      }
+    }
+
+    public Criterion(String condition, Object value, Object secondValue) {
+      this(condition, value, secondValue, null);
+    }
+
+    public Criterion(String condition, Object value, Object secondValue, String typeHandler) {
+      super();
+      this.condition = condition;
+      this.value = value;
+      this.secondValue = secondValue;
+      this.betweenValue = true;
+    }
+
+    public String getCondition() {
+      return condition;
+    }
+
+    public Object getValue() {
+      return value;
+    }
+
+    public Object getSecondValue() {
+      return secondValue;
+    }
+
+    public boolean isNoValue() {
+      return noValue;
+    }
+
+    public boolean isSingleValue() {
+      return singleValue;
+    }
+
+    public boolean isBetweenValue() {
+      return betweenValue;
+    }
+
+    public boolean isListValue() {
+      return listValue;
+    }
+
+    public boolean isOrValue() {
+      if (orValue && this.value instanceof Collection) {
+        return ((Collection<?>) this.value)
+            .stream()
+            .filter(item -> item instanceof OrCriteria)
+            .map(OrCriteria.class::cast)
+            .anyMatch(GeneratedCriteria::isValid);
+      }
+      return false;
+    }
+  }
+
+  /**
+   * 排序方式
+   */
+  public enum Order {
+    /**
+     * 升序
+     */
+    ASC,
+    /**
+     * 降序
+     */
+    DESC
+  }
+
+  /**
+   * 查询条件是否为空
+   *
+   * @return 查询条件是否为空
+   */
+  public boolean isEmpty() {
+    if (oredCriteria.size() == 0 && lastCriteria == null) {
+      return true;
+    }
+    boolean noCriteria = true;
+    List<Criteria<T>> checkList = new ArrayList<>(oredCriteria);
+    if (lastCriteria != null) {
+      checkList.add(lastCriteria);
+    }
+    for (Criteria<T> criteria : checkList) {
+      if (!criteria.getCriteria().isEmpty()) {
+        noCriteria = false;
+        break;
+      }
+    }
+    return noCriteria;
+  }
+
+  /**
+   * 是否包含更新字段
+   *
+   * @param column 字段名
+   * @return 字段值
+   */
+  public Boolean setValuesContains(String column) {
+    return this.setValues.stream().anyMatch(criterion -> {
+      if (criterion.noValue) {
+        String[] split = criterion.getCondition().split("=");
+        return split[0].contains(column);
+      } else {
+        return criterion.getCondition().contains(column);
+      }
+    });
+  }
+
+  /**
+   * 转换为字段对应的列信息：获取方法引用对应的列信息
+   *
+   * @return 方法引用对应的列信息
+   */
+  public static <T> String toColumn(Fn<T, Object> fn) {
+    return toEntityColumn(fn).column();
+  }
+
+  /**
+   * 转换为字段对应的列信息：获取方法引用对应的列信息
+   *
+   * @return 方法引用对应的列信息
+   */
+  public static <T> EntityColumn toEntityColumn(Fn<T, Object> fn) {
+    return fn.toEntityColumn();
+  }
+}

--- a/mapper/src/main/java/io/mybatis/mapper/wrapper/Wrapper.java
+++ b/mapper/src/main/java/io/mybatis/mapper/wrapper/Wrapper.java
@@ -328,6 +328,15 @@ public class Wrapper<T> {
   }
 
   /**
+   * 设置最后一个条件
+   *
+   * @param lastCriteria 条件
+   */
+  public void setLastCriteria(Criteria<T> lastCriteria) {
+    this.lastCriteria = lastCriteria;
+  }
+
+  /**
    * 是否使用 distince
    *
    * @return distince
@@ -1109,12 +1118,13 @@ public class Wrapper<T> {
 
     /**
      * 最后一组条件
-     * <p>
-     * 重复调用将覆盖
      *
      * @return 条件
      */
     public Criteria<T> last() {
+      if (currentWrapper.lastCriteria != null) {
+        return currentWrapper.lastCriteria;
+      }
       Criteria<T> criteria = currentWrapper.createCriteriaInternal();
       currentWrapper.lastCriteria = criteria;
       return criteria;

--- a/mapper/src/main/java/io/mybatis/mapper/wrapper/WrapperMapper.java
+++ b/mapper/src/main/java/io/mybatis/mapper/wrapper/WrapperMapper.java
@@ -1,0 +1,169 @@
+package io.mybatis.mapper.wrapper;
+
+import io.mybatis.provider.Caching;
+import io.mybatis.provider.EntityInfoMapper;
+import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.exceptions.TooManyResultsException;
+import org.apache.ibatis.session.RowBounds;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Wrapper 相关方法
+ *
+ * @param <T> 实体类
+ * @param <E> 符合Wrapper数据结构的对象，也可以是 MBG 生成 XXXWrapper 对象。
+ * @author liuzh
+ */
+public interface WrapperMapper<T, E> extends EntityInfoMapper<T> {
+
+  /**
+   * 获取 Wrapper 对象
+   *
+   * @return Wrapper 对象
+   */
+  default Wrapper<T> sql() {
+    return new Wrapper<>();
+  }
+
+  /**
+   * 获取 Wrapper 对象 并 Criteria 条件
+   *
+   * @return Criteria 对象
+   */
+  default Wrapper.Criteria<T> where() {
+    return new Wrapper<T>().where();
+  }
+
+  /**
+   * 保存实体（字段不为空）
+   *
+   * @param entity 实体类
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @InsertProvider(type = WrapperProvider.class, method = WrapperProvider.insertInWrapper)
+  int insertInWrapper(T entity);
+
+  /**
+   * 保存实体（字段可为空）
+   *
+   * @param entity 实体类
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @InsertProvider(type = WrapperProvider.class, method = WrapperProvider.insertNullableInWrapper)
+  int insertNullableInWrapper(T entity);
+
+  /**
+   * 根据主键更新实体（字段不为空）
+   *
+   * @param entity 实体类
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @UpdateProvider(type = WrapperProvider.class, method = WrapperProvider.updateByIdInWrapper)
+  int updateByIdInWrapper(T entity);
+
+  /**
+   * 根据主键更新实体（字段可为空）
+   *
+   * @param entity 实体类
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @UpdateProvider(type = WrapperProvider.class, method = WrapperProvider.updateNullableByIdInWrapper)
+  int updateNullableByIdInWrapper(T entity);
+
+  /**
+   * 根据主键删除
+   *
+   * @param id 主键
+   * @return 1成功，0失败
+   */
+  @Lang(Caching.class)
+  @DeleteProvider(type = WrapperProvider.class, method = WrapperProvider.deleteByIdInWrapper)
+  int deleteByIdInWrapper(Object id);
+
+  /**
+   * 根据主键查询实体
+   *
+   * @param id 主键
+   * @return 实体
+   */
+  @Lang(Caching.class)
+  @SelectProvider(type = WrapperProvider.class, method = WrapperProvider.selectByIdInWrapper)
+  Optional<T> selectByIdInWrapper(Object id);
+
+  /**
+   * 根据 Wrapper 条件批量更新实体信息
+   *
+   * @param entity  实体类
+   * @param wrapper 条件
+   * @return 大于等于1成功，0失败
+   */
+  @Lang(Caching.class)
+  @UpdateProvider(type = WrapperProvider.class, method = WrapperProvider.updateByWrapper)
+  int updateByWrapper(@Param("entity") T entity, @Param("wrapper") E wrapper);
+
+  /**
+   * 根据 Wrapper 删除
+   *
+   * @param wrapper 条件
+   * @return 大于等于1成功，0失败
+   */
+  @Lang(Caching.class)
+  @DeleteProvider(type = WrapperProvider.class, method = WrapperProvider.deleteByWrapper)
+  int deleteByWrapper(E wrapper);
+
+  /**
+   * 根据 Wrapper 条件批量查询
+   *
+   * @param wrapper 条件
+   * @return 实体列表
+   */
+  @Lang(Caching.class)
+  @SelectProvider(type = WrapperProvider.class, method = WrapperProvider.selectByWrapper)
+  List<T> selectListByWrapper(E wrapper);
+
+  /**
+   * 根据 Wrapper 条件批量查询
+   *
+   * @param rowBounds 分页信息
+   * @param wrapper   条件
+   * @return 实体列表
+   */
+  List<T> selectListByWrapper(RowBounds rowBounds, E wrapper);
+
+  /**
+   * 根据 Wrapper 条件查询单个实体
+   *
+   * @param wrapper @param wrapper 条件
+   * @return 单个实体，查询结果由多条时报错
+   * @throws TooManyResultsException exception
+   */
+  @Lang(Caching.class)
+  @SelectProvider(type = WrapperProvider.class, method = WrapperProvider.selectByWrapper)
+  Optional<T> selectOneThrowByWrapper(E wrapper) throws TooManyResultsException;
+
+  /**
+   * 根据 Wrapper 条件查询单个实体
+   *
+   * @param wrapper 条件
+   * @return 单个实体
+   */
+  default Optional<T> selectOneByWrapper(E wrapper) {
+    return selectListByWrapper(new RowBounds(0, 1), wrapper).stream().findFirst();
+  }
+
+  /**
+   * 根据 Wrapper 条件查询总数
+   *
+   * @param wrapper 条件
+   * @return 总数
+   */
+  @Lang(Caching.class)
+  @SelectProvider(type = WrapperProvider.class, method = WrapperProvider.countByWrapper)
+  long countByWrapper(E wrapper);
+}

--- a/mapper/src/main/java/io/mybatis/mapper/wrapper/WrapperProvider.java
+++ b/mapper/src/main/java/io/mybatis/mapper/wrapper/WrapperProvider.java
@@ -1,0 +1,382 @@
+package io.mybatis.mapper.wrapper;
+
+import io.mybatis.mapper.wrapper.logical.LogicDeleteUtil;
+import io.mybatis.provider.EntityColumn;
+import io.mybatis.provider.EntityTable;
+import io.mybatis.provider.SqlScript;
+import org.apache.ibatis.builder.annotation.ProviderContext;
+
+import java.util.stream.Collectors;
+
+/**
+ * 基础的增删改查操作
+ *
+ * @author dyun
+ */
+public class WrapperProvider {
+
+  /*
+   * ====================================provider for entity ====================================
+   */
+
+  /**
+   * 获取ID条件： 形式 column = #{property} 形式的字符串
+   *
+   * @param entity 实体类
+   * @return ID条件
+   */
+  public static String getIdEqualsProperty(EntityTable entity) {
+    return entity.idColumns().stream()
+        .map(EntityColumn::columnEqualsProperty)
+        .collect(Collectors.joining(" AND "));
+  }
+
+  public static final String insertInWrapper = "insertInWrapper";
+
+  /**
+   * 保存实体（字段不为空）
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String insertInWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, new SqlScript() {
+      @Override
+      public String getSql(EntityTable entity) {
+        return "INSERT INTO " + entity.tableName()
+            + trimSuffixOverrides("(", ")", ",", () ->
+            entity.insertColumns().stream().map(column ->
+                ifTest(column.notNullTest(), () -> column.column() + ",")
+            ).collect(Collectors.joining(LF)))
+            + trimSuffixOverrides(" VALUES (", ")", ",", () ->
+            entity.insertColumns().stream().map(column ->
+                ifTest(column.notNullTest(), () -> column.variables() + ",")
+            ).collect(Collectors.joining(LF)));
+      }
+    });
+  }
+
+  public static final String insertNullableInWrapper = "insertNullableInWrapper";
+
+  /**
+   * 保存实体（字段可为空）
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String insertNullableInWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, entity -> "INSERT INTO " + entity.tableName()
+        + "(" + entity.insertColumnList() + ")"
+        + " VALUES (" + entity.insertColumns().stream()
+        .map(EntityColumn::variables).collect(Collectors.joining(",")) + ")");
+  }
+
+  public static final String updateByIdInWrapper = "updateByIdInWrapper";
+
+  /**
+   * 根据主键更新实体（字段不为空）
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String updateByIdInWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, new SqlScript() {
+      @Override
+      public String getSql(EntityTable entity) {
+        return "UPDATE " + entity.tableName()
+            + set(() ->
+            entity.updateColumns().stream().map(column ->
+                ifTest(column.notNullTest(), () -> column.columnEqualsProperty() + ",")
+            ).collect(Collectors.joining(LF)))
+            + " WHERE " + getIdEqualsProperty(entity)
+            + LogicDeleteUtil.andNotDelete(entity);
+      }
+    });
+  }
+
+  public static final String updateNullableByIdInWrapper = "updateNullableByIdInWrapper";
+
+  /**
+   * 根据主键更新实体（字段可为空）
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String updateNullableByIdInWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, new SqlScript() {
+      @Override
+      public String getSql(EntityTable entity) {
+        return "UPDATE " + entity.tableName()
+            + " SET " + entity.updateColumns().stream().map(EntityColumn::columnEqualsProperty).collect(Collectors.joining(","))
+            + " WHERE " + getIdEqualsProperty(entity)
+            + LogicDeleteUtil.andNotDelete(entity);
+      }
+    });
+  }
+
+  public static final String deleteByIdInWrapper = "deleteByIdInWrapper";
+
+  /**
+   * 根据主键删除
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String deleteByIdInWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, entity -> {
+      if (LogicDeleteUtil.getLogicColumn(entity) != null) {
+        return "UPDATE " + entity.tableName()
+            + " SET " + LogicDeleteUtil.setIsDelete(entity)
+            + " WHERE " + getIdEqualsProperty(entity);
+      }
+      return "DELETE FROM " + entity.tableName()
+          + " WHERE " + getIdEqualsProperty(entity);
+    });
+  }
+
+  public static final String selectByIdInWrapper = "selectByIdInWrapper";
+
+  /**
+   * 根据主键查询实体
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String selectByIdInWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, new SqlScript() {
+      @Override
+      public String getSql(EntityTable entity) {
+        return "SELECT " + entity.baseColumnAsPropertyList()
+            + " FROM " + entity.tableName()
+            + where(() -> getIdEqualsProperty(entity)
+            + LogicDeleteUtil.andNotDelete(entity));
+      }
+    });
+  }
+
+  /*
+   * ====================================provider for wrapper ====================================
+   */
+
+  public static final String updateByWrapper = "updateByWrapper";
+
+  /**
+   * 根据 Wrapper 条件批量更新实体信息
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String updateByWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, new SqlScript() {
+      @Override
+      public String getSql(EntityTable entity) {
+        return variableNotNull("wrapper", "Wrapper cannot be null")
+            + ifTest("wrapper.startSql != null and wrapper.startSql != ''", () -> "${wrapper.startSql}")
+            + "UPDATE " + entity.tableName()
+            + set(() ->
+            setClause("wrapper.") +
+                entity.updateColumns().stream().map(column ->
+                    ifTest("!wrapper.setValuesContains('" + column.column() + "')", () ->
+                        choose(() -> whenTest("wrapper.updateNullable",
+                            () -> column.columnEqualsProperty("entity.") + ","))
+                            + choose(() -> whenTest("!wrapper.updateNullable and " + column.notNullTest("entity."),
+                            () -> column.columnEqualsProperty("entity.") + ",")))
+                ).collect(Collectors.joining(LF)))
+            // 是否允许空条件，默认允许(不防全表更新或删除)，允许时不检查查询条件
+            + (entity.getPropBoolean("updateByWrapper.allowEmpty", true) ?
+            "" : variableIsFalse("wrapper.isEmpty()", "Wrapper Criteria cannot be empty"))
+            + whereClause("wrapper.", LogicDeleteUtil.andNotDelete(entity))
+            + ifTest("wrapper.endSql != null and wrapper.endSql != ''", () -> "${wrapper.endSql}");
+      }
+    });
+  }
+
+  public static final String deleteByWrapper = "deleteByWrapper";
+
+  /**
+   * 根据 Wrapper 删除
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String deleteByWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, (entity, util) -> {
+      String sql = util.ifTest("startSql != null and startSql != ''", () -> "${startSql}");
+      if (LogicDeleteUtil.getLogicColumn(entity) != null) {
+        sql = sql + "UPDATE " + entity.tableName() + " SET " + LogicDeleteUtil.setIsDelete(entity);
+      } else {
+        sql = sql + "DELETE FROM " + entity.tableName();
+      }
+      return sql
+          + util.parameterNotNull("Wrapper cannot be null")
+          // 是否允许空条件，默认允许(不防全表更新或删除)，允许时不检查查询条件
+          + (entity.getPropBoolean("deleteByWrapper.allowEmpty", true) ?
+          "" : util.variableIsFalse("_parameter.isEmpty()", "Wrapper Criteria cannot be empty"))
+          + whereClause("", "")
+          + util.ifTest("endSql != null and endSql != ''", () -> "${endSql}");
+    });
+  }
+
+  public static final String selectByWrapper = "selectByWrapper";
+
+  /**
+   * 根据 Wrapper 条件批量查询，根据 Wrapper 条件查询总数，查询结果的数量由方法定义
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String selectByWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, new SqlScript() {
+      @Override
+      public String getSql(EntityTable entity) {
+        return ifTest("startSql != null and startSql != ''", () -> "${startSql}")
+            + "SELECT "
+            + ifTest("distinct", () -> "distinct ")
+            + ifTest("selectColumns != null and selectColumns != ''", () -> "${selectColumns}")
+            + ifTest("selectColumns == null or selectColumns == ''", entity::baseColumnAsPropertyList)
+            + " FROM " + entity.tableName()
+            + ifParameterNotNull(() -> whereClause("", LogicDeleteUtil.andNotDelete(entity)))
+            + ifParameterIsNull(() -> LogicDeleteUtil.whereNotDelete(entity))
+            + ifTest("orderByClause != null", () -> " ORDER BY ${orderByClause}")
+            + ifTest("orderByClause == null", () -> entity.orderByColumn().orElse(""))
+            + ifTest("endSql != null and endSql != ''", () -> "${endSql}");
+      }
+    });
+  }
+
+  public static final String countByWrapper = "countByWrapper";
+
+  /**
+   * 根据 Wrapper 条件查询总数
+   *
+   * @param providerContext 上下文
+   * @return cacheKey
+   */
+  public static String countByWrapper(ProviderContext providerContext) {
+    return SqlScript.caching(providerContext, new SqlScript() {
+      @Override
+      public String getSql(EntityTable entity) {
+        return ifTest("startSql != null and startSql != ''", () -> "${startSql}")
+            + "SELECT COUNT(1) "
+            + " FROM " + entity.tableName()
+            + ifParameterNotNull(() -> whereClause("", LogicDeleteUtil.andNotDelete(entity)))
+            + ifParameterIsNull(() -> LogicDeleteUtil.whereNotDelete(entity))
+            + ifTest("endSql != null and endSql != ''", () -> "${endSql}");
+      }
+    });
+  }
+
+  /*
+   * ==============================================xml fragment start==============================================
+   */
+
+  /**
+   * 生成 &lt;if test="_parameter != null"&gt; 标签包装的 xml 结构，允许参数为空时使用，
+   *
+   * @param content 标签中的内容
+   * @return &lt;if test="_parameter == null"&gt; 标签包装的 xml 结构
+   */
+  public static String ifParameterIsNull(SqlScript.LRSupplier content) {
+    return String.format("<if test=\"_parameter == null\">%s\n</if> ", content.getWithLR());
+  }
+
+  /**
+   * Wrapper 结构的动态 SQL 查询条件
+   *
+   * @param prefix         用于多个参数时， 需传入wrapperName，Wrapper 对应 @Param("wrapper"), 注意需自己拼接 . 条件
+   * @param logicDeleteSql 逻辑删除片段 需传入 AND + 逻辑删除条件, 注意需自己拼接AND条件
+   * @return xml形式查询条件
+   */
+  public static String whereClause(String prefix, String logicDeleteSql) {
+    String clause = "<where>\n" +
+        "  <foreach collection=\"_defaultWrapperName点oredCriteria\" item=\"criteria\" separator=\" OR \">\n" +
+        "    <if test=\"criteria.valid\">\n" +
+        "      <trim prefix=\"(\" prefixOverrides=\"AND\" suffix=\")\">\n"
+        + useCriterions("criteria.")
+        + "      </trim>\n" +
+        "    </if>\n" +
+        "  </foreach>\n" +
+        "  <if test=\"_defaultWrapperName点lastCriteria != null and _defaultWrapperName点lastCriteria.valid\">\n"
+        + useCriterions("_defaultWrapperName点lastCriteria.")
+        + "  </if>\n" +
+        "  _defaultLogicDeleteSql_\n" +
+        "</where>\n";
+    return clause.replace("_defaultWrapperName点", prefix).replace("_defaultLogicDeleteSql_", logicDeleteSql);
+  }
+
+  /**
+   * 迭代使用 criterion list 条件列表
+   */
+  public static String useCriterions(String criterionName) {
+    return criterions.replace("_defaultCriterionsName点", criterionName);
+  }
+
+  /**
+   * criterion list 条件列表
+   */
+  public static final String criterions = "        <foreach collection=\"_defaultCriterionsName点criteria\" item=\"criterion\">\n" +
+      "          <choose>\n" +
+      "            <when test=\"criterion.noValue\">\n" +
+      "              AND ${criterion.condition}\n" +
+      "            </when>\n" +
+      "            <when test=\"criterion.singleValue\">\n" +
+      "              AND ${criterion.condition} #{criterion.value}\n" +
+      "            </when>\n" +
+      "            <when test=\"criterion.betweenValue\">\n" +
+      "              AND ${criterion.condition} #{criterion.value} AND #{criterion.secondValue}\n" +
+      "            </when>\n" +
+      "            <when test=\"criterion.listValue\">\n" +
+      "              AND ${criterion.condition}\n" +
+      "              <foreach collection=\"criterion.value\" item=\"listItem\" open=\"(\" separator=\",\" close=\")\">\n" +
+      "                #{listItem}\n" +
+      "              </foreach>\n" +
+      "            </when>\n" +
+      "            <when test=\"criterion.orValue\">\n" +
+      "              <foreach collection=\"criterion.value\" item=\"orCriteria\" separator=\" OR \" open=\" AND (\" close=\")\">\n" +
+      "                <if test=\"orCriteria.valid\">\n" +
+      "                  <trim prefix=\"(\" prefixOverrides=\"AND\" suffix=\")\">\n" +
+      "                    <foreach collection=\"orCriteria.criteria\" item=\"criterion\">\n" +
+      "                      <choose>\n" +
+      "                        <when test=\"criterion.noValue\">\n" +
+      "                          AND ${criterion.condition}\n" +
+      "                        </when>\n" +
+      "                        <when test=\"criterion.singleValue\">\n" +
+      "                          AND ${criterion.condition} #{criterion.value}\n" +
+      "                        </when>\n" +
+      "                        <when test=\"criterion.betweenValue\">\n" +
+      "                          AND ${criterion.condition} #{criterion.value} AND #{criterion.secondValue}\n" +
+      "                        </when>\n" +
+      "                        <when test=\"criterion.listValue\">\n" +
+      "                          AND ${criterion.condition}\n" +
+      "                          <foreach collection=\"criterion.value\" item=\"listItem\" open=\"(\" separator=\",\" close=\")\">\n" +
+      "                            #{listItem}\n" +
+      "                          </foreach>\n" +
+      "                        </when>\n" +
+      "                      </choose>\n" +
+      "                    </foreach>\n" +
+      "                  </trim>\n" +
+      "                </if>\n" +
+      "              </foreach>\n" +
+      "            </when>\n" +
+      "          </choose>\n" +
+      "        </foreach>\n";
+
+  /**
+   * Wrapper 结构的动态 SQL SET语句
+   * 多个参数时， 需传入wrapperName，Wrapper 对应 @Param("wrapper")
+   */
+  public static String setClause(String prefix) {
+    String clause = "<foreach collection=\"_defaultWrapperName点setValues\" item=\"setValue\">\n" +
+        "  <choose>\n" +
+        "    <when test=\"setValue.noValue\">\n" +
+        "      ${setValue.condition},\n" +
+        "    </when>\n" +
+        "    <when test=\"setValue.singleValue\">\n" +
+        "      ${setValue.condition} = #{setValue.value},\n" +
+        "    </when>\n" +
+        "  </choose>\n" +
+        "</foreach>\n";
+    return clause.replace("_defaultWrapperName点", prefix);
+  }
+
+}

--- a/mapper/src/main/java/io/mybatis/mapper/wrapper/logical/LogicDeleteUtil.java
+++ b/mapper/src/main/java/io/mybatis/mapper/wrapper/logical/LogicDeleteUtil.java
@@ -1,0 +1,110 @@
+package io.mybatis.mapper.wrapper.logical;
+
+import io.mybatis.provider.EntityColumn;
+import io.mybatis.provider.EntityTable;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 逻辑删除工具类
+ *
+ * @author dyun
+ */
+public class LogicDeleteUtil {
+
+  /**
+   * 已删除, isDelete = 1 或者 isDelete IS NOT NULL
+   */
+  public static String isDelete(String prefix, EntityTable entity) {
+    EntityColumn logicColumn = getLogicColumn(entity);
+    if (logicColumn != null) {
+      TableLogic annotation = logicColumn.field().getAnnotation(TableLogic.class);
+      if (annotation.dateType()) {
+        return String.format(" %s %s IS NOT NULL ", prefix, logicColumn.column());
+      }
+      if (!"".equals(annotation.value())) {
+        return String.format(" %s %s = %s ", prefix, logicColumn.column(), annotation.value());
+      }
+    }
+    return "";
+  }
+
+  /**
+   * 未删除, isDelete != 1 或者 isDelete IS NULL
+   */
+  public static String notDelete(String prefix, EntityTable entity) {
+    EntityColumn logicColumn = getLogicColumn(entity);
+    if (logicColumn != null) {
+      TableLogic annotation = logicColumn.field().getAnnotation(TableLogic.class);
+      if (annotation.dateType()) {
+        return String.format(" %s %s IS NULL ", prefix, logicColumn.column());
+      }
+      if (!"".equals(annotation.value())) {
+        return String.format(" %s %s != %s ", prefix, logicColumn.column(), annotation.value());
+      }
+    }
+    return "";
+  }
+
+  /**
+   * 已删除, isDelete = 1 或者 isDelete IS NOT NULL
+   */
+  public static String andIsDelete(EntityTable entity) {
+    return isDelete("AND", entity);
+  }
+
+  /**
+   * 未删除, isDelete != 1 或者 isDelete IS NULL
+   */
+  public static String andNotDelete(EntityTable entity) {
+    return notDelete("AND", entity);
+  }
+
+  /**
+   * 已删除, isDelete = 1 或者 isDelete IS NOT NULL
+   */
+  public static String whereIsDelete(EntityTable entity) {
+    return isDelete("WHERE", entity);
+  }
+
+  /**
+   * 未删除, isDelete != 1 或者 isDelete IS NULL
+   */
+  public static String whereNotDelete(EntityTable entity) {
+    return notDelete("WHERE", entity);
+  }
+
+  /**
+   * 设置字段删除, isDelete = 1 或者 isDelete = 2012-12-12 12:12:12
+   * <p>
+   * 恢复删除请使用update相关接口
+   */
+  public static String setIsDelete(EntityTable entity) {
+    EntityColumn logicColumn = getLogicColumn(entity);
+    if (logicColumn != null) {
+      TableLogic annotation = logicColumn.field().getAnnotation(TableLogic.class);
+      if (annotation.dateType()) {
+        return String.format(" %s = %s ", logicColumn.column(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+      }
+      if (!"".equals(annotation.value())) {
+        return String.format(" %s = %s ", logicColumn.column(), annotation.value());
+      }
+    }
+    return "";
+  }
+
+  /**
+   * 获取逻辑删除字段
+   */
+  public static EntityColumn getLogicColumn(EntityTable entity) {
+    List<EntityColumn> logicColumns = entity.columns().stream().filter(c -> c.field().isAnnotationPresent(TableLogic.class)).collect(Collectors.toList());
+    if (logicColumns.size() > 0) {
+      return logicColumns.get(0);
+    }
+    return null;
+  }
+}
+

--- a/mapper/src/main/java/io/mybatis/mapper/wrapper/logical/TableLogic.java
+++ b/mapper/src/main/java/io/mybatis/mapper/wrapper/logical/TableLogic.java
@@ -1,0 +1,31 @@
+package io.mybatis.mapper.wrapper.logical;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 标记该字段为逻辑状态列
+ * <p>NOTE: 单张表中仅支持标记一个字段。并且，该字段最好是满足@Entity.Column(updatable = false, insertable = false)，这样可以避免其他更新方法误更新逻辑删除状态</p>
+ *
+ * @author hzw
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface TableLogic {
+
+  /**
+   * date类型删除值
+   * 优先级: 1
+   *
+   * @return data类型
+   */
+  boolean dateType() default false;
+
+  /**
+   * 表示逻辑删除的值(比如1 或 是), 默认值: 1
+   * 优先级: 2
+   */
+  String value() default "1";
+}

--- a/mapper/src/test/java/io/mybatis/mapper/model/User.java
+++ b/mapper/src/test/java/io/mybatis/mapper/model/User.java
@@ -17,6 +17,7 @@
 package io.mybatis.mapper.model;
 
 import io.mybatis.mapper.logical.LogicalColumn;
+import io.mybatis.mapper.wrapper.logical.TableLogic;
 import io.mybatis.provider.Entity;
 
 @Entity.Table(value = "user",
@@ -34,6 +35,7 @@ public class User {
   @Entity.Column
   private String sex;
   @LogicalColumn(delete = "0")
+  @TableLogic(value = "0")
   @Entity.Column(updatable = false, insertable = false)
   private Boolean status;
 

--- a/mapper/src/test/java/io/mybatis/mapper/wrapper/UserWrapperMapperTest.java
+++ b/mapper/src/test/java/io/mybatis/mapper/wrapper/UserWrapperMapperTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mybatis.mapper.wrapper;
+
+import io.mybatis.mapper.BaseMapperTest;
+import io.mybatis.mapper.model.User;
+import org.apache.ibatis.exceptions.TooManyResultsException;
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class UserWrapperMapperTest extends BaseMapperTest {
+
+  @Test
+  public void testInsertNullable() {
+    SqlSession sqlSession = getSqlSession();
+    try {
+      UserWrapperWrapperMapper mapper = sqlSession.getMapper(UserWrapperWrapperMapper.class);
+      // ==================testInsertNullable userName插入为null, 覆盖了默认数据库DEFAULT值
+      User user = new User();
+      mapper.insertNullable(user);
+      Assert.assertNotNull(user.getId());
+      user = mapper.selectById(user.getId()).get();
+      Assert.assertNull(user.getUserName());
+      sqlSession.rollback();
+    } finally {
+      //不要忘记关闭sqlSession
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testInsert() {
+    SqlSession sqlSession = getSqlSession();
+    try {
+      UserWrapperWrapperMapper mapper = sqlSession.getMapper(UserWrapperWrapperMapper.class);
+      // ==================testInsert userName未插入, 默认为数据库DEFAULT值
+      User user = new User();
+      user.setSex("性别");
+      mapper.insert(user);
+      Assert.assertNotNull(user.getId());
+      Optional<User> userOptional = mapper.selectById(user.getId());
+      Assert.assertTrue(userOptional.isPresent());
+      Assert.assertEquals("DEFAULT", userOptional.get().getUserName());
+      sqlSession.rollback();
+    } finally {
+      //不要忘记关闭sqlSession
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testUpdateByEntityId() {
+    SqlSession sqlSession = getSqlSession();
+    try {
+      UserWrapperWrapperMapper mapper = sqlSession.getMapper(UserWrapperWrapperMapper.class);
+      // ==================test updateById 测试只更新userName, 未更新sex
+      User userBefore = mapper.selectById(1L).get();
+      User user = new User();
+      user.setId(1L);
+      user.setUserName("男主角");
+      user.setSex(null);
+      Assert.assertEquals(1, mapper.updateById(user));
+      user = mapper.selectById(1L).get();
+      Assert.assertEquals("男主角", user.getUserName());
+      Assert.assertEquals(userBefore.getSex(), user.getSex());
+      // ==================test updateNullableById 测试更新sex为null
+      user.setSex(null);
+      mapper.updateNullableById(user);
+      user = mapper.selectById(1L).get();
+      Assert.assertNull(user.getSex());
+      // ==================test update entity中sex为null了, 测试强制更新sex为女
+      mapper.update(user, mapper.sql()
+          .set(User::getSex, "女").where()
+          .eq(User::getId, user.getId()).build());
+      user = mapper.selectById(1L).get();
+      Assert.assertEquals("女", user.getSex());
+      sqlSession.rollback();
+    } finally {
+      //不要忘记关闭sqlSession
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testSelectByFieldList() {
+    SqlSession sqlSession = getSqlSession();
+    try {
+      UserWrapperWrapperMapper mapper = sqlSession.getMapper(UserWrapperWrapperMapper.class);
+      // ==================test selectList
+      List<User> users = mapper.selectList(mapper.where().in(User::getUserName, Arrays.asList("张无忌", "赵敏", "周芷若")).build());
+      Assert.assertEquals(3, users.size());
+      Assert.assertEquals("张无忌", users.get(0).getUserName());
+      Assert.assertEquals("赵敏", users.get(1).getUserName());
+      Assert.assertEquals("周芷若", users.get(2).getUserName());
+      // ==================test selectByIds
+      List<User> userList = mapper.selectByIds(1L, 2L, 3L);
+      Assert.assertEquals(3, userList.size());
+    } finally {
+      //不要忘记关闭sqlSession
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testDeleteByFieldList() {
+    SqlSession sqlSession = getSqlSession();
+    try {
+      UserWrapperWrapperMapper mapper = sqlSession.getMapper(UserWrapperWrapperMapper.class);
+      // ==================test deleteById
+      Assert.assertEquals(1, mapper.deleteById(1L));
+      sqlSession.rollback();
+      // ==================test delete
+      Assert.assertEquals(3, mapper.delete(mapper.where().in(User::getUserName, Arrays.asList("张无忌", "赵敏", "周芷若")).build()));
+      Assert.assertFalse(mapper.selectById(1L).isPresent());
+      Assert.assertFalse(mapper.selectById(2L).isPresent());
+      Assert.assertFalse(mapper.selectById(3L).isPresent());
+      sqlSession.rollback();
+      // ==================test deleteByIds
+      Assert.assertEquals(3, mapper.deleteByIds(1L, 2L, 3L));
+      Assert.assertFalse(mapper.selectById(1L).isPresent());
+      Assert.assertFalse(mapper.selectById(2L).isPresent());
+      Assert.assertFalse(mapper.selectById(3L).isPresent());
+    } finally {
+      //不要忘记关闭sqlSession
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testOrCondition() {
+    try (SqlSession sqlSession = getSqlSession()) {
+      UserWrapperWrapperMapper mapper = sqlSession.getMapper(UserWrapperWrapperMapper.class);
+      Wrapper<User> sql = mapper.sql();
+      sql.where()
+          .eq(User::getSex, "男")
+          .and(or1 -> or1
+                  .like(User::getUserName, "杨%"),
+              or2 -> or2
+                  .like(User::getUserName, "俞%")
+                  .like(User::getUserName, "舟%"));
+      // ==================test count
+      Assert.assertEquals(2, mapper.count(sql));
+      mapper.selectList(null);
+      mapper.selectList(new Wrapper<>());
+      mapper.count(null);
+      mapper.count(new Wrapper<>());
+    }
+  }
+
+  @Test
+  public void testExampleWrapper() {
+    try (SqlSession sqlSession = getSqlSession()) {
+      UserWrapperWrapperMapper mapper = sqlSession.getMapper(UserWrapperWrapperMapper.class);
+      //查询 "sex=男 or name like '杨%' 的数量
+      long count = mapper.where().eq(User::getSex, "男")
+          .and(
+              c -> c.startsWith(User::getUserName, "杨")
+          ).execute(mapper::count);
+      Assert.assertEquals(1, count);
+      //查询 "sex=男 and (name like '杨%' or (name like '俞%' and name like '%舟')) 的数量
+      count = mapper.where().eq(User::getSex, "男")
+          .and(
+              c -> c.startsWith(User::getUserName, "杨"),
+              c -> c.startsWith(User::getUserName, "俞").endsWith(User::getUserName, "舟")
+          ).execute(mapper::count);
+      Assert.assertEquals(2, count);
+      // ==================test selectList
+      //查询 name 和 sex 列，条件为 (name like '杨%' or sex = '男') or ( id > 1 and id <= 16 and sex = '女' ) 的数据
+      List<User> users = mapper.sql()
+          .select(User::getUserName, User::getSex)
+          .where().and(c -> c.startsWith(User::getUserName, "杨"),
+              c -> c.eq(User::getSex, "男"))
+          .or()
+          .gt(User::getId, 1L)
+          .le(User::getId, 16L)
+          .eq(User::getSex, "女").execute(mapper::selectList);
+
+      //构建的wrapper可以多次使用
+      //查询条件为 id > 50 or id <= 5 or sex = '女'
+      Wrapper<User> wrapper = mapper.where()
+          .gt(User::getId, 50L)
+          .or()
+          .le(User::getId, 5L)
+          .or()
+          .eq(User::getSex, "女").build();
+      // ==================test selectList
+      //使用当前条件获取前5条数据
+      users = mapper.selectList(new RowBounds(0, 5), wrapper);
+      Assert.assertEquals(5, users.size());
+      int idSize = mapper.selectList(wrapper).stream().map(User::getId).collect(Collectors.toSet()).size();
+      //追加条件后查询数量
+      count = wrapper.select(User::getId).distinct(true).where().execute(mapper::count);
+      Assert.assertEquals(idSize, count);
+
+      //根据条件"name=张无忌"，更新名字和性别
+      Assert.assertEquals(1, (int) mapper.sql()
+          .set(User::getUserName, "弓长无忌")
+          .set(User::getSex, "M")
+          .where().eq(User::getUserName, "张无忌").execute(new User(), mapper::update));
+      //根据条件"sex=M"查询数量
+      Assert.assertEquals(1, (long) mapper.where().eq(User::getSex, "M").execute(mapper::count));
+
+      mapper.where()
+          .eq(User::getSex, "女")
+          .and(c -> c.gt(User::getId, 40), c -> c.lt(User::getId, 10))
+          .or()
+          .startsWith(User::getUserName, "张")
+          .orderByAsc(User::getId).execute(mapper::selectList);
+
+      mapper.where()
+          .eq(false, User::getSex, "女")
+          .and(c -> c.gt(User::getId, 40), c -> c.lt(false, User::getId, 10))
+          .or()
+          .startsWith(User::getUserName, "张")
+          .orderByAsc(User::getId).execute(mapper::selectList);
+
+      Optional<User> userOne = mapper.selectOne(mapper.where().like(User::getUserName, "张").build());
+      userOne.orElseThrow(RuntimeException::new);
+
+      try {
+        Optional<User> userOneThrow = mapper.selectOneThrow(mapper.where().like(User::getUserName, "张").build());
+      } catch (TooManyResultsException e) {
+        Assert.assertTrue(true);
+      }
+    }
+  }
+}
+
+

--- a/mapper/src/test/java/io/mybatis/mapper/wrapper/UserWrapperWrapperMapper.java
+++ b/mapper/src/test/java/io/mybatis/mapper/wrapper/UserWrapperWrapperMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mybatis.mapper.wrapper;
+
+import io.mybatis.mapper.model.User;
+
+public interface UserWrapperWrapperMapper extends
+//    BaseMapper<User, Long>,
+    PureWrapperMapper<User, Long> {
+
+}


### PR DESCRIPTION
#### 新增wrapper类及其实现：

建议：这几处建议稍后提交pr
1. Fn工具类放到provider中作为基础支持。（provider项目）
2. SqlScript类提供ifParameterIsNull方法 （provider项目）
3. ExampleWrapper为开发者提供lambda方法的抽象，开发者提供自定义mapper实现传入构造方法实现 .listxxx() .selectxxx()方法（mapper项目）

因当前项目已实现entitymapper, examplemaper, logicalmapper。 接口方法众多，provider冗余太多（牵一发动全身，改一处注意多处）。该实现建议作为新用法为新项目提供支持。

1. wrapper与example类似, 但提供统一的lambda写法.(写法与mybaits SQL类类似),保持编码一致
2. wrapper增加lastCriteria最后一个条件, 不参与 or 条件拼接 (可用于租户ID, 店铺ID, 数据权限等场景的查询条件)
4. wrapper类增加updateNullable与setValuesContains, 如果setValues存在则强制设定,如果不存在则取entity中字段,字段是否可更新为null取决于updateNullable属性
5. wrapper类中增加execute方法, 可使用lambda function 调用mapper方法
6. wrapper类增加逻辑删除, 可以定义date类型或string类型
7. PureWrapperMapper为新项目准备，仅提供15个方法支持
 ```
int insert(T entity);
int insertNullable(T entity);

int updateById(T entity);
int updateNullableById(T entity);
int update(@Param("entity") T entity, @Param("wrapper") Wrapper<T> wrapper);

int deleteById(I id);
int deleteByIds(I... ids);
int delete(Wrapper<T> wrapper);

Optional<T> selectById(I id);
List<T> selectByIds(I... ids);

Optional<T> selectOne(Wrapper<T> wrapper);
Optional<T> selectOneThrow(Wrapper<T> wrapper);

List<T> selectList(Wrapper<T> wrapper);
List<T> selectList(RowBounds rowBounds, Wrapper<T> wrapper);

long count(Wrapper<T> wrapper);
 ```