### PR TITLE
Fix ClassNotFoundException for jakarta.persistence.Table

### DIFF
--- a/jakarta-jpa/pom.xml
+++ b/jakarta-jpa/pom.xml
@@ -41,7 +41,7 @@
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
       <version>3.1.0</version>
-      <scope>provided</scope>
+      <scope>compile</scope>
     </dependency>
 
     <!-- test -->


### PR DESCRIPTION
Related to #109

Updates the `jakarta.persistence-api` dependency scope in `jakarta-jpa/pom.xml` to ensure it's included at runtime.

- Changes the scope of `jakarta.persistence-api` from `provided` to `compile`. This ensures the dependency is included in the runtime classpath, addressing the `ClassNotFoundException` for `jakarta.persistence.Table`.
- Maintains the version of `jakarta.persistence-api` at `3.1.0`, aligning with the recommended version to resolve the issue.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mybatis-mapper/mapper/issues/109?shareId=d0761bba-5a12-41c9-b827-5f59102fc780).