### PR TITLE
feat: 为ExampleService添加findFirst方法, 用于查询条件匹配到多个结果导致findOne不适用的场景

### DIFF
--- a/service/src/main/java/io/mybatis/service/AbstractService.java
+++ b/service/src/main/java/io/mybatis/service/AbstractService.java
@@ -260,6 +260,18 @@ public abstract class AbstractService<T, I extends Serializable, M extends BaseM
   }
 
   /**
+   * 根据 example 条件查询并返回第1个结果(当结果多于1个时不抛出异常)
+   *
+   * @param example 查询条件
+   * @return 实体
+   */
+  @Override
+  public T findFirst(Example<T> example) {
+    List<T> list = baseMapper.selectByExample(example);
+    return (list == null || list.isEmpty()) ? null : list.get(0);
+  }
+
+  /**
    * 根据 example 条件查询
    *
    * @param example 查询条件

--- a/service/src/main/java/io/mybatis/service/ExampleService.java
+++ b/service/src/main/java/io/mybatis/service/ExampleService.java
@@ -74,6 +74,14 @@ public interface ExampleService<T, I extends Serializable> {
   T findOne(Example<T> example);
 
   /**
+   * 根据 example 条件查询并返回第1个结果(当结果多于1个时不抛出异常)
+   *
+   * @param example 查询条件
+   * @return 实体
+   */
+  T findFirst(Example<T> example);
+
+  /**
    * 根据 example 条件查询
    *
    * @param example 查询条件


### PR DESCRIPTION
为ExampleService添加findFirst方法, 用于查询条件匹配到多个结果导致findOne不适用的场景, 返回符合条件的第1条数据，其排序可由example里面的orderBy来灵活指定，在复杂查询条件的系统中经常用到。