### PR TITLE
完善空白符判断逻辑，兼容特殊字符(如\u200B)出现的场景

### DIFF
--- a/common/src/main/java/io/mybatis/common/util/Utils.java
+++ b/common/src/main/java/io/mybatis/common/util/Utils.java
@@ -93,7 +93,7 @@ public class Utils {
     return Character.isWhitespace(c)
         || Character.isSpaceChar(c)
         || c == '\ufeff'
-        || c == '\u202a';
+        || Character.getType(c) == Character.FORMAT;
   }
 
   /**

--- a/common/src/test/java/io/mybatis/common/util/UtilsTest.java
+++ b/common/src/test/java/io/mybatis/common/util/UtilsTest.java
@@ -1,0 +1,36 @@
+package io.mybatis.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Utils单元测试用例
+ */
+public class UtilsTest {
+
+  /**
+   * 测试常见的空白字符
+   */
+  @Test
+  public void testBlankChar() {
+    Assert.assertTrue(Utils.isBlankChar(' '));
+    Assert.assertTrue(Utils.isBlankChar('\n'));
+    Assert.assertTrue(Utils.isBlankChar('\r'));
+    Assert.assertTrue(Utils.isBlankChar('\t'));
+    Assert.assertTrue(Utils.isBlankChar('\f'));
+
+    Assert.assertTrue(Utils.isBlankChar('\u00A0'));
+    Assert.assertTrue(Utils.isBlankChar('\ufeff'));
+    Assert.assertTrue(Utils.isBlankChar('\u3000'));
+    Assert.assertTrue(Utils.isBlankChar('\u202a'));
+    // 处理来自Word的文本时，偶见此空白字符
+    Assert.assertTrue(Utils.isBlankChar('\u200B'));
+
+    Assert.assertFalse(Utils.isBlankChar('a'));
+    Assert.assertFalse(Utils.isBlankChar('z'));
+    Assert.assertFalse(Utils.isBlankChar('0'));
+    Assert.assertFalse(Utils.isBlankChar('9'));
+    Assert.assertFalse(Utils.isBlankChar('/'));
+    Assert.assertFalse(Utils.isBlankChar('\\'));
+  }
+}


### PR DESCRIPTION
来自外部数据源(如Word文档)的字符串偶然会出现 \u200B 等特殊字符，应当视为空白符处理。因此优化了 Utils 里面的 isBlankChar 方法的判断逻辑。详见源码及单元测试用例。